### PR TITLE
tweak moderator role

### DIFF
--- a/test/models/comment_test.exs
+++ b/test/models/comment_test.exs
@@ -25,6 +25,16 @@ defmodule Helheim.CommentTest do
       assert Comment.deletable_by?(comment3, user)
     end
 
+    test "returns true if the specified user is a mod regardless of the type of comment" do
+      comment1 = insert(:blog_post_comment)
+      comment2 = insert(:profile_comment)
+      comment3 = insert(:photo_comment)
+      user     = insert(:user, role: "mod")
+      assert Comment.deletable_by?(comment1, user)
+      assert Comment.deletable_by?(comment2, user)
+      assert Comment.deletable_by?(comment3, user)
+    end
+
     test "returns true if the specified comment is a profile comment and the specified user is the same as the profile of the comment" do
       comment = insert(:profile_comment)
       user1   = comment.profile
@@ -81,6 +91,12 @@ defmodule Helheim.CommentTest do
 
     test "it returns true if the user is an admin" do
       user    = insert(:user, role: "admin")
+      comment = insert(:profile_comment, inserted_at: Timex.shift(Timex.now, minutes: -11))
+      assert Comment.editable_by?(comment, user)
+    end
+
+    test "it returns true if the user is a mod" do
+      user    = insert(:user, role: "mod")
       comment = insert(:profile_comment, inserted_at: Timex.shift(Timex.now, minutes: -11))
       assert Comment.editable_by?(comment, user)
     end

--- a/test/models/forum_reply_test.exs
+++ b/test/models/forum_reply_test.exs
@@ -85,6 +85,12 @@ defmodule Helheim.ForumReplyTest do
       reply = insert(:forum_reply, inserted_at: Timex.shift(Timex.now, minutes: -11))
       assert ForumReply.editable_by?(reply, user)
     end
+
+    test "it returns true if the user is a mod" do
+      user  = insert(:user, role: "mod")
+      reply = insert(:forum_reply, inserted_at: Timex.shift(Timex.now, minutes: -11))
+      assert ForumReply.editable_by?(reply, user)
+    end
   end
 
   describe "in_order/1" do

--- a/test/models/forum_topic_test.exs
+++ b/test/models/forum_topic_test.exs
@@ -149,6 +149,12 @@ defmodule Helheim.ForumTopicTest do
       topic = insert(:forum_topic, inserted_at: Timex.shift(Timex.now, minutes: -11))
       assert ForumTopic.editable_by?(topic, user)
     end
+
+    test "it returns true if the user is a mod" do
+      user  = insert(:user, role: "mod")
+      topic = insert(:forum_topic, inserted_at: Timex.shift(Timex.now, minutes: -11))
+      assert ForumTopic.editable_by?(topic, user)
+    end
   end
 
   describe "in_order/1" do

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -177,15 +177,15 @@ defmodule Helheim.UserTest do
     end
   end
 
-  describe "moderator?/1" do
-    test "it returns true if the role of the user is 'moderator'" do
-      user = insert(:user, role: "moderator")
-      assert User.moderator?(user)
+  describe "mod?/1" do
+    test "it returns true if the role of the user is 'mod'" do
+      user = insert(:user, role: "mod")
+      assert User.mod?(user)
     end
 
-    test "it returns false if the role of the user is not 'moderator'" do
+    test "it returns false if the role of the user is not 'mod'" do
       user = insert(:user, role: "nope")
-      refute User.moderator?(user)
+      refute User.mod?(user)
     end
   end
 

--- a/web/models/comment.ex
+++ b/web/models/comment.ex
@@ -61,6 +61,7 @@ defmodule Helheim.Comment do
   end
 
   def deletable_by?(_, %User{role: "admin"}), do: true
+  def deletable_by?(_, %User{role: "mod"}), do: true
   def deletable_by?(%Comment{profile_id: profile_id}, user) when is_integer(profile_id), do: profile_id == user.id
   def deletable_by?(%Comment{blog_post_id: blog_post_id} = comment, user) when is_integer(blog_post_id), do: comment.blog_post.user_id == user.id
   def deletable_by?(%Comment{photo_id: photo_id} = comment, user) when is_integer(photo_id), do: comment.photo.photo_album.user_id == user.id

--- a/web/models/concerns/time_limited_editable_concern.ex
+++ b/web/models/concerns/time_limited_editable_concern.ex
@@ -1,11 +1,13 @@
 defmodule Helheim.TimeLimitedEditableConcern do
+  alias Helheim.User
+
   defmacro __using__(_) do
     quote do
       @edit_timelimit_in_minutes 60
       def edit_timelimit_in_minutes, do: @edit_timelimit_in_minutes
 
       def editable_by?(struct, user) do
-        Helheim.User.admin?(user) || (
+        User.admin?(user) || User.mod?(user) || (
           user_id(struct) == user.id &&
           Timex.after?(
             struct.inserted_at,

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -287,8 +287,8 @@ defmodule Helheim.User do
   def admin?(%User{role: "admin"}), do: true
   def admin?(_), do: false
 
-  def moderator?(%User{role: "moderator"}), do: true
-  def moderator?(_), do: false
+  def mod?(%User{role: "mod"}), do: true
+  def mod?(_), do: false
 
   def delete!(user) do
     photo_albums = assoc(user, :photo_albums) |> Repo.all

--- a/web/views/profile_helpers.ex
+++ b/web/views/profile_helpers.ex
@@ -37,7 +37,7 @@ defmodule Helheim.ProfileHelpers do
   end
 
   defp role_badge("admin"), do: [{:safe, " "}, content_tag(:span, "admin", class: "badge badge-primary")]
-  defp role_badge("moderator"), do: [{:safe, " "}, content_tag(:span, "mod", class: "badge badge-primary")]
+  defp role_badge("mod"), do: [{:safe, " "}, content_tag(:span, "mod", class: "badge badge-primary")]
   defp role_badge(_), do: {:safe, ""}
 
   defp avatar(nil), do: img_tag(static_path(Endpoint, "/images/deleted_user_avatar_tiny.png"), class: "img-avatar")


### PR DESCRIPTION
- Rename “moderator” to “mod” for brevity.
- Make comments, forum-topics and forum-replies editable by mods.
- Make comments deletable by mods.