### PR TITLE
implement incognito feature

### DIFF
--- a/lib/helheim/models/user.ex
+++ b/lib/helheim/models/user.ex
@@ -44,6 +44,7 @@ defmodule Helheim.User do
     field :notification_sound,              :string
     field :mute_notifications,              :boolean
     field :session_id,                      :string
+    field :incognito,                       :boolean
 
     timestamps(type: :utc_datetime_usec)
 

--- a/lib/helheim/models/visitor_log_entry.ex
+++ b/lib/helheim/models/visitor_log_entry.ex
@@ -29,6 +29,7 @@ defmodule Helheim.VisitorLogEntry do
       order_by: [desc: e.updated_at]
   end
 
+  def track!(%{incognito: true}, _), do: {:error, "User must not be incognito"}
   def track!(user, %BlogPost{} = subject), do: track!(user, subject.user_id, subject, :blog_post)
   def track!(user, %PhotoAlbum{} = subject), do: track!(user, subject.user_id, subject, :photo_album)
   def track!(user, %Photo{} = subject), do: track!(user, subject.photo_album.user_id, subject, :photo)

--- a/lib/helheim/services/online_users_service.ex
+++ b/lib/helheim/services/online_users_service.ex
@@ -3,18 +3,24 @@ defmodule Helheim.OnlineUsersService do
   alias Helheim.User
   alias HelheimWeb.Presence
 
-  def count(current_user_id), do: user_ids(current_user_id) |> length()
+  def count(current_user), do: user_ids(current_user) |> length()
 
-  def list(current_user_id) do
+  def list(current_user) do
     User
-    |> User.with_ids(user_ids(current_user_id))
+    |> User.with_ids(user_ids(current_user))
     |> User.sort("last_login_at", "desc")
     |> Repo.all()
   end
 
   ### PRIVATE
-  defp user_ids(current_user_id) do
-    Map.merge(%{inspect(current_user_id) => %{}}, Presence.list("status"))
+  defp user_ids(%{id: current_user_id, incognito: current_user_incognito}) do
+    all = Map.merge(%{inspect(current_user_id) => %{metas: [%{incognito: current_user_incognito}]}}, Presence.list("status"))
+    excluding_incognito = :maps.filter fn _, v -> !is_incognito?(v) end, all
+
+    excluding_incognito
     |> Map.keys
   end
+
+  defp is_incognito?(%{metas: [%{incognito: incognito}]}), do: incognito
+  defp is_incognito?(_), do: false
 end

--- a/lib/helheim_web/auth/track_login.ex
+++ b/lib/helheim_web/auth/track_login.ex
@@ -28,6 +28,7 @@ defmodule HelheimWeb.Plug.TrackLogin do
 
   defp load_user(conn), do: {:ok, Guardian.Plug.current_resource(conn)}
 
+  defp maybe_track_login(_conn, %{incognito: true} = user, _id), do: {:ok, user}
   defp maybe_track_login(_conn, %{session_id: stored_id} = user, id) when stored_id == id, do: {:ok, user}
   defp maybe_track_login(conn, user, id) do
     changeset = Ecto.Changeset.change user,

--- a/lib/helheim_web/channels/status_channel.ex
+++ b/lib/helheim_web/channels/status_channel.ex
@@ -14,7 +14,8 @@ defmodule HelheimWeb.StatusChannel do
   def handle_info(:after_join, socket) do
     push socket, "presence_state", Presence.list(socket)
     {:ok, _} = Presence.track(socket, current_resource(socket).id, %{
-      online_at: inspect(System.system_time(:seconds))
+      online_at: inspect(System.system_time(:seconds)),
+      incognito: current_resource(socket).incognito
     })
     {:noreply, socket}
   end

--- a/lib/helheim_web/controllers/online_user_controller.ex
+++ b/lib/helheim_web/controllers/online_user_controller.ex
@@ -4,7 +4,7 @@ defmodule HelheimWeb.OnlineUserController do
 
   def index(conn, _params) do
     user = current_resource(conn)
-    users = OnlineUsersService.list(user.id)
+    users = OnlineUsersService.list(user)
     count = length(users)
     render conn, "index.html", count: count, users: users
   end

--- a/lib/helheim_web/templates/layout/sidebar.html.eex
+++ b/lib/helheim_web/templates/layout/sidebar.html.eex
@@ -20,7 +20,7 @@
         <%= link to: online_user_path(@conn, :index), class: "nav-link" do %>
           <i class="fa fa-signal"></i>
           <%= gettext("Online users") %>
-          <span class="badge badge-pill badge-secondary"><%= Helheim.OnlineUsersService.count(current_resource(@conn).id) %></span>
+          <span class="badge badge-pill badge-secondary"><%= Helheim.OnlineUsersService.count(current_resource(@conn)) %></span>
         <% end %>
       </li>
       <li class="nav-item">

--- a/priv/repo/migrations/20201125134208_add_incognito_to_user.exs
+++ b/priv/repo/migrations/20201125134208_add_incognito_to_user.exs
@@ -1,0 +1,9 @@
+defmodule Helheim.Repo.Migrations.AddIncognitoToUser do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :incognito, :boolean, default: false
+    end
+  end
+end

--- a/test/helheim/visitor_log_entry_test.exs
+++ b/test/helheim/visitor_log_entry_test.exs
@@ -49,6 +49,14 @@ defmodule Helheim.VisitorLogEntryTest do
       assert Repo.get(Helheim.BlogPost, blog_post.id).visitor_count == 0
     end
 
+    test "it never tracks a view or increments visitor_count on a blog_post when the user is incognito" do
+      user = insert(:user, incognito: true)
+      blog_post   = insert(:blog_post)
+      {:error, _} = VisitorLogEntry.track!(user, blog_post)
+      refute Repo.one(VisitorLogEntry)
+      assert Repo.get(Helheim.BlogPost, blog_post.id).visitor_count == 0
+    end
+
     test "it successfully tracks a view on a photo album and increments the visitor_count", %{user: user} do
       photo_album            = insert(:photo_album)
       {:ok, %{entry: entry}} = VisitorLogEntry.track!(user, photo_album)
@@ -77,6 +85,14 @@ defmodule Helheim.VisitorLogEntryTest do
 
     test "it never tracks a view or increments visitor_count on a photo_album belonging to the user", %{user: user} do
       photo_album = insert(:photo_album, user: user)
+      {:error, _} = VisitorLogEntry.track!(user, photo_album)
+      refute Repo.one(VisitorLogEntry)
+      assert Repo.get(Helheim.PhotoAlbum, photo_album.id).visitor_count == 0
+    end
+
+    test "it never tracks a view or increments visitor_count on a photo_album when the user is incognito" do
+      user = insert(:user, incognito: true)
+      photo_album = insert(:photo_album)
       {:error, _} = VisitorLogEntry.track!(user, photo_album)
       refute Repo.one(VisitorLogEntry)
       assert Repo.get(Helheim.PhotoAlbum, photo_album.id).visitor_count == 0
@@ -116,6 +132,15 @@ defmodule Helheim.VisitorLogEntryTest do
       assert Repo.get(Helheim.Photo, photo.id).visitor_count == 0
     end
 
+    test "it never tracks a view or increments visitor_count on a photo when the user is incognito" do
+      user        = insert(:user, incognito: true)
+      photo_album = insert(:photo_album)
+      photo       = insert(:photo, photo_album: photo_album)
+      {:error, _} = VisitorLogEntry.track!(user, photo)
+      refute Repo.one(VisitorLogEntry)
+      assert Repo.get(Helheim.Photo, photo.id).visitor_count == 0
+    end
+
     test "it successfully tracks a view on a profile and increments the visitor_count", %{user: user} do
       profile                = insert(:user)
       {:ok, %{entry: entry}} = VisitorLogEntry.track!(user, profile)
@@ -146,6 +171,14 @@ defmodule Helheim.VisitorLogEntryTest do
       {:error, _} = VisitorLogEntry.track!(user, user)
       refute Repo.one(VisitorLogEntry)
       assert Repo.get(Helheim.User, user.id).visitor_count == 0
+    end
+
+    test "it never tracks a view or increments visitor_count on a profile when the user is incognito" do
+      user        = insert(:user, incognito: true)
+      profile     = insert(:user)
+      {:error, _} = VisitorLogEntry.track!(user, profile)
+      refute Repo.one(VisitorLogEntry)
+      assert Repo.get(Helheim.User, profile.id).visitor_count == 0
     end
 
     test "it allows the user to have multiple different entries for different subjects", %{user: user} do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -16,7 +16,8 @@ defmodule Helheim.Factory do
       total_donated: 1000,
       comment_count: 0,
       verified_at: nil,
-      verifier_id: nil
+      verifier_id: nil,
+      incognito: false
     }
   end
 


### PR DESCRIPTION
This implements the foundation for an incognito feature.
When a user is incognito they will not be shown in the list of online users and we will not track when they logged in the last time.
Incognito users will also not be tracked in visitor log entries.

This feature is only intended for admins/mods at this point and currently no UI elements allows for switching this feature on or off. It can therefore only be activated or deactivated by changing a users `incognito` attribute directly in the database.