### PR TITLE
Fix client IP resolution behind Cloudflare + Fly.io proxy chain

### DIFF
--- a/lib/helheim_web/endpoint.ex
+++ b/lib/helheim_web/endpoint.ex
@@ -11,22 +11,10 @@ defmodule HelheimWeb.Endpoint do
     plug Phoenix.Ecto.SQL.Sandbox
   end
 
-  plug RemoteIp, proxies: ~w[
-    103.21.244.0/22
-    103.22.200.0/22
-    103.31.4.0/22
-    104.16.0.0/12
-    108.162.192.0/18
-    131.0.72.0/22
-    141.101.64.0/18
-    162.158.0.0/15
-    172.64.0.0/13
-    173.245.48.0/20
-    188.114.96.0/20
-    190.93.240.0/20
-    197.234.240.0/22
-    198.41.128.0/17
-  ]
+  # Cloudflare always sets CF-Connecting-IP to the real client IP, overwriting
+  # any forged value. Using this single-value header avoids maintaining proxy
+  # CIDR lists for Cloudflare and Fly.io in the X-Forwarded-For chain.
+  plug RemoteIp, headers: ~w[cf-connecting-ip]
 
   plug Phoenix.LiveDashboard.RequestLogger,
     param_key: "request_logger",


### PR DESCRIPTION
Switch from parsing X-Forwarded-For (which required maintaining CIDR lists for every proxy hop) to reading Cloudflare's CF-Connecting-IP header directly. This header always contains the real client IP and cannot be spoofed by end users, eliminating the need for proxy CIDR configuration entirely.