### PR TITLE
Derive the Last.fm auth callback from the request host

### DIFF
--- a/config/dev.secret.exs.example
+++ b/config/dev.secret.exs.example
@@ -26,8 +26,7 @@ config :helheim, :recaptcha,
 # https://www.last.fm/api/account/create to get these credentials.
 config :helheim, :lastfm,
   api_key: "LASTFM_API_KEY",
-  shared_secret: "LASTFM_SHARED_SECRET",
-  callback_url: "http://dev.helheim.dk:4000/lastfm_account/callback"
+  shared_secret: "LASTFM_SHARED_SECRET"
 
 # Optional: use the "dev" branch of the Neon database instead of the local
 # postgres server configured in dev.exs. Fetch the connection string with:

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -66,6 +66,5 @@ if config_env() == :prod do
 
   config :helheim, :lastfm,
     api_key: System.get_env("LASTFM_API_KEY"),
-    shared_secret: System.get_env("LASTFM_SHARED_SECRET"),
-    callback_url: "https://#{host}/lastfm_account/callback"
+    shared_secret: System.get_env("LASTFM_SHARED_SECRET")
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -61,8 +61,7 @@ config :helheim, :recaptcha,
 # Configure Last.fm
 config :helheim, :lastfm,
   api_key: "lastfm_test_api_key",
-  shared_secret: "lastfm_test_shared_secret",
-  callback_url: "http://localhost:4001/lastfm_account/callback"
+  shared_secret: "lastfm_test_shared_secret"
 
 # Configure wallaby
 config :wallaby,

--- a/lib/helheim/lastfm/client.ex
+++ b/lib/helheim/lastfm/client.ex
@@ -2,7 +2,7 @@ defmodule Helheim.Lastfm.Client do
   @moduledoc """
   Thin Req based client for the Last.fm web auth flow and API endpoints used
   by the listening history feature. Configured via `config :helheim, :lastfm`
-  with `api_key`, `shared_secret` and `callback_url`.
+  with `api_key` and `shared_secret`.
 
   Note that the Last.fm API usually reports errors as an HTTP 200 response
   with an `{"error": code, "message": ...}` body, so bodies are inspected
@@ -12,8 +12,13 @@ defmodule Helheim.Lastfm.Client do
   @auth_url "https://www.last.fm/api/auth/"
   @api_url "https://ws.audioscrobbler.com/2.0/"
 
-  def auth_url do
-    query = URI.encode_query(%{api_key: config()[:api_key], cb: config()[:callback_url]})
+  @doc """
+  The Last.fm authorization page url. The callback must be on the same host
+  the user's browser session lives on, so the caller derives it from the
+  current request rather than from static configuration.
+  """
+  def auth_url(callback_url) do
+    query = URI.encode_query(%{api_key: config()[:api_key], cb: callback_url})
     "#{@auth_url}?#{query}"
   end
 

--- a/lib/helheim_web/controllers/lastfm_account_controller.ex
+++ b/lib/helheim_web/controllers/lastfm_account_controller.ex
@@ -6,7 +6,15 @@ defmodule HelheimWeb.LastfmAccountController do
   def create(conn, _params) do
     conn
     |> put_session(:lastfm_connect_pending, true)
-    |> redirect(external: Client.auth_url())
+    |> redirect(external: Client.auth_url(callback_url(conn)))
+  end
+
+  # The callback must return to the host the user is actually browsing on
+  # (www vs apex domain, dev hosts), since the session cookie holding the
+  # login and the pending flag is scoped to that host.
+  defp callback_url(conn) do
+    uri = %{HelheimWeb.Endpoint.struct_url() | host: conn.host}
+    lastfm_account_url(uri, :callback)
   end
 
   def callback(conn, %{"token" => token}) do

--- a/test/helheim_web/controllers/lastfm_account_controller_test.exs
+++ b/test/helheim_web/controllers/lastfm_account_controller_test.exs
@@ -10,14 +10,24 @@ defmodule HelheimWeb.LastfmAccountControllerTest do
   describe "create/2 when signed in" do
     setup [:create_and_sign_in_user]
 
-    test "redirects to the last.fm authorization url", %{conn: conn} do
+    test "redirects to the last.fm authorization url with a callback on the request host", %{conn: conn} do
       conn = post conn, "/lastfm_account"
       location = redirected_to(conn)
       assert location =~ "https://www.last.fm/api/auth"
       %URI{query: query} = URI.parse(location)
       params = URI.decode_query(query)
       assert params["api_key"] == "lastfm_test_api_key"
-      assert params["cb"] == "http://localhost:4001/lastfm_account/callback"
+      %URI{host: cb_host, path: cb_path} = URI.parse(params["cb"])
+      assert cb_host == conn.host
+      assert cb_path == "/lastfm_account/callback"
+    end
+
+    test "keeps the callback on the host the user is browsing on", %{conn: conn} do
+      conn = %{conn | host: "apex-domain.example"}
+      conn = post conn, "/lastfm_account"
+      %URI{query: query} = URI.parse(redirected_to(conn))
+      %URI{host: cb_host} = URI.parse(URI.decode_query(query)["cb"])
+      assert cb_host == "apex-domain.example"
     end
   end
 


### PR DESCRIPTION
## What

The Last.fm connect flow built its callback URL from the static `HOST` config (`www.helheim.dk`). A user browsing on the apex domain (`helheim.dk`) who started the flow was redirected back to `www.helheim.dk`, where their session cookie — carrying both the login and the connect-pending flag — does not exist, so they landed logged out and the connect failed.

The callback is now derived from the request host (`conn.host` merged onto the endpoint's configured scheme/port), so the flow always returns to the exact host the user started on. The `callback_url` config key is removed everywhere (Last.fm doesn't whitelist callbacks; the `cb` parameter is free-form).

## Testing

Full suite green (1507 tests). New test asserts the callback host follows a non-default request host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)