### PR TITLE
Improve the front page music section

### DIFF
--- a/assets/css/_custom.scss
+++ b/assets/css/_custom.scss
@@ -310,4 +310,20 @@ code {
   }
 }
 
+
+.song-cover-placeholder {
+  width: 64px;
+  height: 64px;
+  min-width: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.25);
+
+  i {
+    font-size: 1.5rem;
+    opacity: 0.5;
+  }
+}
+
 @import "calendar_events";

--- a/lib/helheim/models/song_listen.ex
+++ b/lib/helheim/models/song_listen.ex
@@ -23,6 +23,19 @@ defmodule Helheim.SongListen do
     from l in query, where: l.song_id == ^song.id
   end
 
+  @doc """
+  Collapses the listens to one per song, keeping the newest listen of each,
+  so a song played on repeat only appears once in listing contexts.
+  """
+  def latest_per_song(query) do
+    deduplicated =
+      from l in query,
+        distinct: l.song_id,
+        order_by: [asc: l.song_id, desc: l.played_at]
+
+    from l in subquery(deduplicated)
+  end
+
   def not_from_users(query, nil), do: query
   def not_from_users(query, user_ids) do
     from l in query, where: l.user_id not in ^user_ids

--- a/lib/helheim/music/charts.ex
+++ b/lib/helheim/music/charts.ex
@@ -1,8 +1,7 @@
 defmodule Helheim.Music.Charts do
   @moduledoc """
-  Aggregated listening statistics for the front page. Day and week
-  boundaries are calculated in local Danish time (weeks start on Monday) and
-  converted to UTC for querying.
+  Aggregated listening statistics for the front page, based on rolling
+  windows: the past 24 hours and the past 7 days.
 
   Listens from `excluded_user_ids` (the viewer's ignore list) are left out
   of the charts. The unfiltered charts are cached for a short interval since
@@ -15,14 +14,12 @@ defmodule Helheim.Music.Charts do
   alias Helheim.Repo
   alias Helheim.Song
 
-  @timezone "Europe/Copenhagen"
-
-  def top_songs_today(count, excluded_user_ids \\ nil) do
-    top_songs_since(start_of_day(), count, excluded_user_ids, cache_key: {:top_songs_today, count})
+  def top_songs_last_day(count, excluded_user_ids \\ nil) do
+    top_songs_since(hours_ago(24), count, excluded_user_ids, cache_key: {:top_songs_last_day, count})
   end
 
-  def top_songs_this_week(count, excluded_user_ids \\ nil) do
-    top_songs_since(start_of_week(), count, excluded_user_ids, cache_key: {:top_songs_this_week, count})
+  def top_songs_last_week(count, excluded_user_ids \\ nil) do
+    top_songs_since(hours_ago(24 * 7), count, excluded_user_ids, cache_key: {:top_songs_last_week, count})
   end
 
   def top_songs_since(since, count, excluded_user_ids \\ nil, opts \\ []) do
@@ -42,10 +39,9 @@ defmodule Helheim.Music.Charts do
     end
   end
 
-  def start_of_day, do: Timex.now(@timezone) |> Timex.beginning_of_day() |> to_utc()
-  def start_of_week, do: Timex.now(@timezone) |> Timex.beginning_of_week() |> to_utc()
-
-  defp to_utc(datetime), do: Timex.Timezone.convert(datetime, "Etc/UTC")
+  def hours_ago(hours) do
+    DateTime.add(DateTime.utc_now(), -hours * 3600, :second)
+  end
 
   defp cache_ttl, do: Application.get_env(:helheim, :chart_cache_ttl_ms, 60_000)
 end

--- a/lib/helheim_web/controllers/page_controller.ex
+++ b/lib/helheim_web/controllers/page_controller.ex
@@ -54,9 +54,10 @@ defmodule HelheimWeb.PageController do
     recent_song_listens =
       SongListen
       |> SongListen.not_from_users(conn.assigns[:ignoree_ids])
+      |> SongListen.latest_per_song
       |> SongListen.newest
       |> SongListen.with_preloads
-      |> limit(10)
+      |> limit(5)
       |> Repo.all
 
     render conn, "front_page.html",
@@ -66,8 +67,8 @@ defmodule HelheimWeb.PageController do
       newest_forum_topics: newest_forum_topics,
       upcoming_events: upcoming_events,
       recent_song_listens: recent_song_listens,
-      top_songs_today: Charts.top_songs_today(5, conn.assigns[:ignoree_ids]),
-      top_songs_week: Charts.top_songs_this_week(5, conn.assigns[:ignoree_ids])
+      top_songs_day: Charts.top_songs_last_day(5, conn.assigns[:ignoree_ids]),
+      top_songs_week: Charts.top_songs_last_week(5, conn.assigns[:ignoree_ids])
   end
 
   def terms(conn, _params) do

--- a/lib/helheim_web/controllers/song_controller.ex
+++ b/lib/helheim_web/controllers/song_controller.ex
@@ -6,12 +6,34 @@ defmodule HelheimWeb.SongController do
   alias Helheim.SongListen
   alias Helheim.Music.Charts
 
-  def index(conn, params) do
+  # The full list pages are capped at 100 pages to preserve performance.
+  @max_pages 100
+
+  def recent(conn, params) do
+    listens =
+      SongListen
+      |> SongListen.not_from_users(conn.assigns[:ignoree_ids])
+      |> SongListen.latest_per_song
+      |> SongListen.newest
+      |> SongListen.with_preloads
+      |> capped_paginate(params)
+    render(conn, "recent.html", listens: listens)
+  end
+
+  def top_day(conn, params) do
+    render_top(conn, params, Charts.hours_ago(24), gettext("Top songs, past 24 hours"))
+  end
+
+  def top_week(conn, params) do
+    render_top(conn, params, Charts.hours_ago(24 * 7), gettext("Top songs, past 7 days"))
+  end
+
+  defp render_top(conn, params, since, title) do
     songs =
       Song
-      |> Song.top_by_listens_since(Charts.start_of_week(), conn.assigns[:ignoree_ids])
-      |> Repo.paginate(page: sanitized_page(params["page"]))
-    render(conn, "index.html", songs: songs)
+      |> Song.top_by_listens_since(since, conn.assigns[:ignoree_ids])
+      |> capped_paginate(params)
+    render(conn, "top.html", songs: songs, title: title)
   end
 
   def show(conn, %{"id" => id} = params) do
@@ -50,6 +72,12 @@ defmodule HelheimWeb.SongController do
     conn
     |> put_flash(:success, gettext("Your listens have been removed from this song."))
     |> redirect(to: song_path(conn, :show, song))
+  end
+
+  defp capped_paginate(query, params) do
+    query
+    |> Repo.paginate(page: sanitized_page(params["page"], @max_pages))
+    |> cap_total_pages(@max_pages)
   end
 
   # Users the viewer ignores, plus users who block the viewer, are left out

--- a/lib/helheim_web/pagination_sanitization.ex
+++ b/lib/helheim_web/pagination_sanitization.ex
@@ -9,4 +9,16 @@ defmodule HelheimWeb.PaginationSanitization do
       true -> page
     end
   end
+
+  def sanitized_page(page, max_page) do
+    min(sanitized_page(page), max_page)
+  end
+
+  @doc """
+  Caps a Scrivener page at the given number of pages so that pagination
+  links never lead deeper than the cap.
+  """
+  def cap_total_pages(%Scrivener.Page{} = page, max_page) do
+    %{page | total_pages: min(page.total_pages, max_page)}
+  end
 end

--- a/lib/helheim_web/router.ex
+++ b/lib/helheim_web/router.ex
@@ -130,7 +130,10 @@ defmodule HelheimWeb.Router do
       resources "/notification_subscription", NotificationSubscriptionController, singleton: true, only: [:update]
     end
     resources "/online_users", OnlineUserController, only: [:index]
-    resources "/songs", SongController, only: [:index, :show] do
+    get "/songs/recent", SongController, :recent
+    get "/songs/top/day", SongController, :top_day
+    get "/songs/top/week", SongController, :top_week
+    resources "/songs", SongController, only: [:show] do
       resources "/comments", CommentController, only: [:create, :edit, :update]
       resources "/notification_subscription", NotificationSubscriptionController, singleton: true, only: [:update]
       delete "/my_listens", SongController, :remove_my_listens, as: :my_listens

--- a/lib/helheim_web/templates/page/front_page.html.eex
+++ b/lib/helheim_web/templates/page/front_page.html.eex
@@ -82,7 +82,7 @@
       <div class="card-block">
         <h5 class="mb-1 d-flex justify-content-between">
           <%= gettext "Recent listens" %>
-          <%= link gettext("Show All"), to: song_path(@conn, :index), class: "btn btn-outline-primary btn-sm mb-0" %>
+          <%= link gettext("Show All"), to: song_path(@conn, :recent), class: "btn btn-outline-primary btn-sm mb-0" %>
         </h5>
         <%= for listen <- @recent_song_listens do %>
           <%= render HelheimWeb.SongView, "_listen.html", conn: @conn, listen: listen %>
@@ -92,11 +92,14 @@
 
     <div class="card">
       <div class="card-block">
-        <h5 class="mb-1"><%= gettext "Top songs today" %></h5>
-        <%= if length(@top_songs_today) == 0 do %>
-          <p class="text-muted"><%= gettext "No songs have been listened to today yet..." %></p>
+        <h5 class="mb-1 d-flex justify-content-between">
+          <%= gettext "Top songs, past 24 hours" %>
+          <%= link gettext("Show All"), to: song_path(@conn, :top_day), class: "btn btn-outline-primary btn-sm mb-0" %>
+        </h5>
+        <%= if length(@top_songs_day) == 0 do %>
+          <p class="text-muted"><%= gettext "No songs have been listened to in this period yet..." %></p>
         <% end %>
-        <%= for {song, count} <- @top_songs_today do %>
+        <%= for {song, count} <- @top_songs_day do %>
           <%= render HelheimWeb.SongView, "_song.html", conn: @conn, song: song, listen_count: count %>
         <% end %>
       </div>
@@ -104,9 +107,12 @@
 
     <div class="card">
       <div class="card-block">
-        <h5 class="mb-1"><%= gettext "Top songs this week" %></h5>
+        <h5 class="mb-1 d-flex justify-content-between">
+          <%= gettext "Top songs, past 7 days" %>
+          <%= link gettext("Show All"), to: song_path(@conn, :top_week), class: "btn btn-outline-primary btn-sm mb-0" %>
+        </h5>
         <%= if length(@top_songs_week) == 0 do %>
-          <p class="text-muted"><%= gettext "No songs have been listened to this week yet..." %></p>
+          <p class="text-muted"><%= gettext "No songs have been listened to in this period yet..." %></p>
         <% end %>
         <%= for {song, count} <- @top_songs_week do %>
           <%= render HelheimWeb.SongView, "_song.html", conn: @conn, song: song, listen_count: count %>

--- a/lib/helheim_web/templates/song/_cover.html.eex
+++ b/lib/helheim_web/templates/song/_cover.html.eex
@@ -1,0 +1,7 @@
+<a href="<%= song_path(@conn, :show, @song) %>" class="d-flex mr-1">
+  <%= if @song.cover_image_url_small do %>
+    <img src="<%= @song.cover_image_url_small %>" class="rounded" alt="" width="64" height="64">
+  <% else %>
+    <div class="song-cover-placeholder rounded"><i class="fa fa-music"></i></div>
+  <% end %>
+</a>

--- a/lib/helheim_web/templates/song/_listen.html.eex
+++ b/lib/helheim_web/templates/song/_listen.html.eex
@@ -1,9 +1,5 @@
 <div class="media mb-1">
-  <%= if @listen.song.cover_image_url_small do %>
-    <a href="<%= song_path(@conn, :show, @listen.song) %>">
-      <img src="<%= @listen.song.cover_image_url_small %>" class="d-flex mr-1 rounded" alt="" width="64" height="64">
-    </a>
-  <% end %>
+  <%= render "_cover.html", conn: @conn, song: @listen.song %>
   <div class="media-body">
     <%= link @listen.song.title, to: song_path(@conn, :show, @listen.song) %>
     <br>

--- a/lib/helheim_web/templates/song/_song.html.eex
+++ b/lib/helheim_web/templates/song/_song.html.eex
@@ -1,9 +1,5 @@
 <div class="media mb-1">
-  <%= if @song.cover_image_url_small do %>
-    <a href="<%= song_path(@conn, :show, @song) %>">
-      <img src="<%= @song.cover_image_url_small %>" class="d-flex mr-1 rounded" alt="" width="64" height="64">
-    </a>
-  <% end %>
+  <%= render "_cover.html", conn: @conn, song: @song %>
   <div class="media-body">
     <%= link @song.title, to: song_path(@conn, :show, @song) %>
     <br>

--- a/lib/helheim_web/templates/song/recent.html.eex
+++ b/lib/helheim_web/templates/song/recent.html.eex
@@ -1,0 +1,13 @@
+<h1 class="mt-1"><%= gettext "Recent listens" %></h1>
+
+<div class="card">
+  <div class="card-block">
+    <%= if Enum.empty?(@listens) do %>
+      <p class="text-muted mb-0"><%= gettext "No listens have been tracked yet..." %></p>
+    <% end %>
+    <%= for listen <- @listens do %>
+      <%= render "_listen.html", conn: @conn, listen: listen %>
+    <% end %>
+    <%= pagination_links @conn, @listens %>
+  </div>
+</div>

--- a/lib/helheim_web/templates/song/top.html.eex
+++ b/lib/helheim_web/templates/song/top.html.eex
@@ -1,9 +1,9 @@
-<h1 class="mt-1"><%= gettext "Top songs this week" %></h1>
+<h1 class="mt-1"><%= @title %></h1>
 
 <div class="card">
   <div class="card-block">
     <%= if Enum.empty?(@songs) do %>
-      <p class="text-muted mb-0"><%= gettext "No songs have been listened to this week yet..." %></p>
+      <p class="text-muted mb-0"><%= gettext "No songs have been listened to in this period yet..." %></p>
     <% end %>
     <%= for {song, count} <- @songs do %>
       <%= render "_song.html", conn: @conn, song: song, listen_count: count %>

--- a/priv/gettext/da/LC_MESSAGES/default.po
+++ b/priv/gettext/da/LC_MESSAGES/default.po
@@ -425,7 +425,7 @@ msgstr "Personlige detaljer"
 msgid "Update Account"
 msgstr "Opdatér Konto"
 
-#: lib/helheim/models/user.ex:369
+#: lib/helheim/models/user.ex:372
 #, elixir-autogen
 msgid "does not match your current password"
 msgstr "matcher ikke dit nuværende kodeord"
@@ -485,7 +485,7 @@ msgstr "Nyeste Blogs"
 msgid "Newest Forum Posts"
 msgstr "Nyeste Forumindlæg"
 
-#: lib/helheim_web/templates/page/front_page.html.eex:120
+#: lib/helheim_web/templates/page/front_page.html.eex:129
 #: lib/helheim_web/templates/profile/show.html.eex:111
 #, elixir-autogen
 msgid "Newest Photos"
@@ -614,7 +614,9 @@ msgstr "Tilføj Kommentar"
 #: lib/helheim_web/templates/page/front_page.html.eex:41
 #: lib/helheim_web/templates/page/front_page.html.eex:56
 #: lib/helheim_web/templates/page/front_page.html.eex:85
-#: lib/helheim_web/templates/page/front_page.html.eex:121
+#: lib/helheim_web/templates/page/front_page.html.eex:97
+#: lib/helheim_web/templates/page/front_page.html.eex:112
+#: lib/helheim_web/templates/page/front_page.html.eex:130
 #: lib/helheim_web/templates/profile/show.html.eex:81
 #: lib/helheim_web/templates/profile/show.html.eex:104
 #: lib/helheim_web/templates/profile/show.html.eex:117
@@ -1834,7 +1836,7 @@ msgstr "Vi har modtaget din donation og takker ydmygt for din hjælp med at gør
 msgid "Edited"
 msgstr "Redigeret"
 
-#: lib/helheim/models/user.ex:402
+#: lib/helheim/models/user.ex:405
 #, elixir-autogen
 msgid "I too enjoy registering on websites, fellow human... Bleep Bloop!"
 msgstr "I too enjoy registering on websites, fellow human… Bleep Bloop!"
@@ -2456,7 +2458,7 @@ msgstr "Notifikationer"
 msgid "Preferences"
 msgstr "Præferencer"
 
-#: lib/helheim_web/controllers/preference_controller.ex:18
+#: lib/helheim_web/controllers/preference_controller.ex:17
 #, elixir-autogen
 msgid "Preferences updated!"
 msgstr "Dine præferencer blev gemt!"
@@ -2696,7 +2698,7 @@ msgstr "%{who} skrev en kommentar til sangen: %{what}"
 msgid "Album"
 msgstr "Album"
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:36
+#: lib/helheim_web/templates/song_listen/index.html.eex:38
 #, elixir-autogen, elixir-format
 msgid "All listens"
 msgstr "Alle afspilninger"
@@ -2736,9 +2738,10 @@ msgstr "Afspilninger"
 msgid "Music from %{username}"
 msgstr "Musik fra %{username}"
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:8
-#: lib/helheim_web/templates/song_listen/index.html.eex:20
-#: lib/helheim_web/templates/song_listen/index.html.eex:38
+#: lib/helheim_web/templates/song/recent.html.eex:6
+#: lib/helheim_web/templates/song_listen/index.html.eex:9
+#: lib/helheim_web/templates/song_listen/index.html.eex:21
+#: lib/helheim_web/templates/song_listen/index.html.eex:40
 #, elixir-autogen, elixir-format
 msgid "No listens have been tracked yet..."
 msgstr "Der er ikke registreret nogen afspilninger endnu..."
@@ -2748,22 +2751,13 @@ msgstr "Der er ikke registreret nogen afspilninger endnu..."
 msgid "No one has listened to this song yet..."
 msgstr "Ingen har lyttet til denne sang endnu..."
 
-#: lib/helheim_web/templates/song/index.html.eex:6
-#, elixir-autogen, elixir-format
-msgid "No songs have been listened to this week yet..."
-msgstr "Der er ikke lyttet til nogen sange i denne uge endnu..."
-
-#: lib/helheim_web/templates/page/front_page.html.eex:97
-#, elixir-autogen, elixir-format
-msgid "No songs have been listened to today yet..."
-msgstr "Der er ikke lyttet til nogen sange i dag endnu..."
-
 #: lib/helheim_web/templates/song/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Recent listeners"
 msgstr "Seneste lyttere"
 
 #: lib/helheim_web/templates/page/front_page.html.eex:84
+#: lib/helheim_web/templates/song/recent.html.eex:1
 #, elixir-autogen, elixir-format
 msgid "Recent listens"
 msgstr "Seneste afspilninger"
@@ -2773,33 +2767,22 @@ msgstr "Seneste afspilninger"
 msgid "Song"
 msgstr "Sang"
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:18
+#: lib/helheim_web/templates/song_listen/index.html.eex:19
 #, elixir-autogen, elixir-format
 msgid "Top artists"
 msgstr "Top kunstnere"
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:6
+#: lib/helheim_web/templates/song_listen/index.html.eex:7
 #, elixir-autogen, elixir-format
 msgid "Top songs"
 msgstr "Top sange"
-
-#: lib/helheim_web/templates/page/front_page.html.eex:107
-#: lib/helheim_web/templates/song/index.html.eex:1
-#, elixir-autogen, elixir-format
-msgid "Top songs this week"
-msgstr "Ugens top sange"
-
-#: lib/helheim_web/templates/page/front_page.html.eex:95
-#, elixir-autogen, elixir-format
-msgid "Top songs today"
-msgstr "Dagens top sange"
 
 #: lib/helheim_web/templates/preference/edit.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "You can also delete your entire listening history from the site. This cannot be undone."
 msgstr "Du kan også slette hele din lyttehistorik fra siden. Dette kan ikke fortrydes."
 
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:49
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:57
 #, elixir-autogen, elixir-format
 msgid "Your listening history has been deleted."
 msgstr "Din lyttehistorik er blevet slettet."
@@ -2814,7 +2797,7 @@ msgstr "Er du sikker? Dine afspilninger af denne sang bliver fjernet permanent!"
 msgid "Remove my name from this song"
 msgstr "Fjern mit navn fra denne sang"
 
-#: lib/helheim_web/controllers/song_controller.ex:48
+#: lib/helheim_web/controllers/song_controller.ex:73
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr "Dine afspilninger er blevet fjernet fra denne sang."
@@ -2885,18 +2868,37 @@ msgstr "Forbindelsen til din Last.fm-konto er i stykker, og vi kan ikke længere
 msgid "Your Last.fm account %{username} is connected and your listening history is shared on the site."
 msgstr "Din Last.fm-konto %{username} er forbundet, og din lyttehistorik bliver delt på siden."
 
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:26
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:33
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:34
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:41
 #, elixir-autogen, elixir-format
 msgid "Your Last.fm account could not be connected. Please try again."
 msgstr "Din Last.fm-konto kunne ikke forbindes. Prøv venligst igen."
 
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:41
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:49
 #, elixir-autogen, elixir-format
 msgid "Your Last.fm account has been disconnected."
 msgstr "Din Last.fm-konto er blevet afbrudt."
 
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:21
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:29
 #, elixir-autogen, elixir-format
 msgid "Your Last.fm account is now connected!"
 msgstr "Din Last.fm-konto er nu forbundet!"
+
+#: lib/helheim_web/templates/page/front_page.html.eex:100
+#: lib/helheim_web/templates/page/front_page.html.eex:115
+#: lib/helheim_web/templates/song/top.html.eex:6
+#, elixir-autogen, elixir-format
+msgid "No songs have been listened to in this period yet..."
+msgstr "Der er ikke lyttet til nogen sange i denne periode endnu..."
+
+#: lib/helheim_web/controllers/song_controller.ex:24
+#: lib/helheim_web/templates/page/front_page.html.eex:96
+#, elixir-autogen, elixir-format
+msgid "Top songs, past 24 hours"
+msgstr "Top sange, seneste 24 timer"
+
+#: lib/helheim_web/controllers/song_controller.ex:28
+#: lib/helheim_web/templates/page/front_page.html.eex:111
+#, elixir-autogen, elixir-format
+msgid "Top songs, past 7 days"
+msgstr "Top sange, seneste 7 dage"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -414,7 +414,7 @@ msgstr ""
 msgid "Update Account"
 msgstr ""
 
-#: lib/helheim/models/user.ex:369
+#: lib/helheim/models/user.ex:372
 #, elixir-autogen
 msgid "does not match your current password"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "Newest Forum Posts"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:120
+#: lib/helheim_web/templates/page/front_page.html.eex:129
 #: lib/helheim_web/templates/profile/show.html.eex:111
 #, elixir-autogen
 msgid "Newest Photos"
@@ -603,7 +603,9 @@ msgstr ""
 #: lib/helheim_web/templates/page/front_page.html.eex:41
 #: lib/helheim_web/templates/page/front_page.html.eex:56
 #: lib/helheim_web/templates/page/front_page.html.eex:85
-#: lib/helheim_web/templates/page/front_page.html.eex:121
+#: lib/helheim_web/templates/page/front_page.html.eex:97
+#: lib/helheim_web/templates/page/front_page.html.eex:112
+#: lib/helheim_web/templates/page/front_page.html.eex:130
 #: lib/helheim_web/templates/profile/show.html.eex:81
 #: lib/helheim_web/templates/profile/show.html.eex:104
 #: lib/helheim_web/templates/profile/show.html.eex:117
@@ -1823,7 +1825,7 @@ msgstr ""
 msgid "Edited"
 msgstr ""
 
-#: lib/helheim/models/user.ex:402
+#: lib/helheim/models/user.ex:405
 #, elixir-autogen
 msgid "I too enjoy registering on websites, fellow human... Bleep Bloop!"
 msgstr ""
@@ -2445,7 +2447,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: lib/helheim_web/controllers/preference_controller.ex:18
+#: lib/helheim_web/controllers/preference_controller.ex:17
 #, elixir-autogen
 msgid "Preferences updated!"
 msgstr ""
@@ -2685,7 +2687,7 @@ msgstr ""
 msgid "Album"
 msgstr ""
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:36
+#: lib/helheim_web/templates/song_listen/index.html.eex:38
 #, elixir-autogen, elixir-format
 msgid "All listens"
 msgstr ""
@@ -2725,9 +2727,10 @@ msgstr ""
 msgid "Music from %{username}"
 msgstr ""
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:8
-#: lib/helheim_web/templates/song_listen/index.html.eex:20
-#: lib/helheim_web/templates/song_listen/index.html.eex:38
+#: lib/helheim_web/templates/song/recent.html.eex:6
+#: lib/helheim_web/templates/song_listen/index.html.eex:9
+#: lib/helheim_web/templates/song_listen/index.html.eex:21
+#: lib/helheim_web/templates/song_listen/index.html.eex:40
 #, elixir-autogen, elixir-format
 msgid "No listens have been tracked yet..."
 msgstr ""
@@ -2737,22 +2740,13 @@ msgstr ""
 msgid "No one has listened to this song yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/index.html.eex:6
-#, elixir-autogen, elixir-format
-msgid "No songs have been listened to this week yet..."
-msgstr ""
-
-#: lib/helheim_web/templates/page/front_page.html.eex:97
-#, elixir-autogen, elixir-format
-msgid "No songs have been listened to today yet..."
-msgstr ""
-
 #: lib/helheim_web/templates/song/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Recent listeners"
 msgstr ""
 
 #: lib/helheim_web/templates/page/front_page.html.eex:84
+#: lib/helheim_web/templates/song/recent.html.eex:1
 #, elixir-autogen, elixir-format
 msgid "Recent listens"
 msgstr ""
@@ -2762,25 +2756,14 @@ msgstr ""
 msgid "Song"
 msgstr ""
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:18
+#: lib/helheim_web/templates/song_listen/index.html.eex:19
 #, elixir-autogen, elixir-format
 msgid "Top artists"
 msgstr ""
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:6
+#: lib/helheim_web/templates/song_listen/index.html.eex:7
 #, elixir-autogen, elixir-format
 msgid "Top songs"
-msgstr ""
-
-#: lib/helheim_web/templates/page/front_page.html.eex:107
-#: lib/helheim_web/templates/song/index.html.eex:1
-#, elixir-autogen, elixir-format
-msgid "Top songs this week"
-msgstr ""
-
-#: lib/helheim_web/templates/page/front_page.html.eex:95
-#, elixir-autogen, elixir-format
-msgid "Top songs today"
 msgstr ""
 
 #: lib/helheim_web/templates/preference/edit.html.eex:69
@@ -2788,7 +2771,7 @@ msgstr ""
 msgid "You can also delete your entire listening history from the site. This cannot be undone."
 msgstr ""
 
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:49
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:57
 #, elixir-autogen, elixir-format
 msgid "Your listening history has been deleted."
 msgstr ""
@@ -2803,7 +2786,7 @@ msgstr ""
 msgid "Remove my name from this song"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:48
+#: lib/helheim_web/controllers/song_controller.ex:73
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr ""
@@ -2874,18 +2857,37 @@ msgstr ""
 msgid "Your Last.fm account %{username} is connected and your listening history is shared on the site."
 msgstr ""
 
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:26
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:33
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:34
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:41
 #, elixir-autogen, elixir-format
 msgid "Your Last.fm account could not be connected. Please try again."
 msgstr ""
 
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:41
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:49
 #, elixir-autogen, elixir-format
 msgid "Your Last.fm account has been disconnected."
 msgstr ""
 
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:21
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:29
 #, elixir-autogen, elixir-format
 msgid "Your Last.fm account is now connected!"
+msgstr ""
+
+#: lib/helheim_web/templates/page/front_page.html.eex:100
+#: lib/helheim_web/templates/page/front_page.html.eex:115
+#: lib/helheim_web/templates/song/top.html.eex:6
+#, elixir-autogen, elixir-format
+msgid "No songs have been listened to in this period yet..."
+msgstr ""
+
+#: lib/helheim_web/controllers/song_controller.ex:24
+#: lib/helheim_web/templates/page/front_page.html.eex:96
+#, elixir-autogen, elixir-format
+msgid "Top songs, past 24 hours"
+msgstr ""
+
+#: lib/helheim_web/controllers/song_controller.ex:28
+#: lib/helheim_web/templates/page/front_page.html.eex:111
+#, elixir-autogen, elixir-format
+msgid "Top songs, past 7 days"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -414,7 +414,7 @@ msgstr ""
 msgid "Update Account"
 msgstr ""
 
-#: lib/helheim/models/user.ex:369
+#: lib/helheim/models/user.ex:372
 #, elixir-autogen
 msgid "does not match your current password"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "Newest Forum Posts"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:120
+#: lib/helheim_web/templates/page/front_page.html.eex:129
 #: lib/helheim_web/templates/profile/show.html.eex:111
 #, elixir-autogen
 msgid "Newest Photos"
@@ -603,7 +603,9 @@ msgstr ""
 #: lib/helheim_web/templates/page/front_page.html.eex:41
 #: lib/helheim_web/templates/page/front_page.html.eex:56
 #: lib/helheim_web/templates/page/front_page.html.eex:85
-#: lib/helheim_web/templates/page/front_page.html.eex:121
+#: lib/helheim_web/templates/page/front_page.html.eex:97
+#: lib/helheim_web/templates/page/front_page.html.eex:112
+#: lib/helheim_web/templates/page/front_page.html.eex:130
 #: lib/helheim_web/templates/profile/show.html.eex:81
 #: lib/helheim_web/templates/profile/show.html.eex:104
 #: lib/helheim_web/templates/profile/show.html.eex:117
@@ -1823,7 +1825,7 @@ msgstr ""
 msgid "Edited"
 msgstr ""
 
-#: lib/helheim/models/user.ex:402
+#: lib/helheim/models/user.ex:405
 #, elixir-autogen
 msgid "I too enjoy registering on websites, fellow human... Bleep Bloop!"
 msgstr ""
@@ -2445,7 +2447,7 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: lib/helheim_web/controllers/preference_controller.ex:18
+#: lib/helheim_web/controllers/preference_controller.ex:17
 #, elixir-autogen
 msgid "Preferences updated!"
 msgstr ""
@@ -2685,7 +2687,7 @@ msgstr ""
 msgid "Album"
 msgstr ""
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:36
+#: lib/helheim_web/templates/song_listen/index.html.eex:38
 #, elixir-autogen, elixir-format
 msgid "All listens"
 msgstr ""
@@ -2725,9 +2727,10 @@ msgstr ""
 msgid "Music from %{username}"
 msgstr ""
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:8
-#: lib/helheim_web/templates/song_listen/index.html.eex:20
-#: lib/helheim_web/templates/song_listen/index.html.eex:38
+#: lib/helheim_web/templates/song/recent.html.eex:6
+#: lib/helheim_web/templates/song_listen/index.html.eex:9
+#: lib/helheim_web/templates/song_listen/index.html.eex:21
+#: lib/helheim_web/templates/song_listen/index.html.eex:40
 #, elixir-autogen, elixir-format
 msgid "No listens have been tracked yet..."
 msgstr ""
@@ -2737,22 +2740,13 @@ msgstr ""
 msgid "No one has listened to this song yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/index.html.eex:6
-#, elixir-autogen, elixir-format
-msgid "No songs have been listened to this week yet..."
-msgstr ""
-
-#: lib/helheim_web/templates/page/front_page.html.eex:97
-#, elixir-autogen, elixir-format
-msgid "No songs have been listened to today yet..."
-msgstr ""
-
 #: lib/helheim_web/templates/song/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Recent listeners"
 msgstr ""
 
 #: lib/helheim_web/templates/page/front_page.html.eex:84
+#: lib/helheim_web/templates/song/recent.html.eex:1
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Recent listens"
 msgstr ""
@@ -2762,25 +2756,14 @@ msgstr ""
 msgid "Song"
 msgstr ""
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:18
+#: lib/helheim_web/templates/song_listen/index.html.eex:19
 #, elixir-autogen, elixir-format
 msgid "Top artists"
 msgstr ""
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:6
+#: lib/helheim_web/templates/song_listen/index.html.eex:7
 #, elixir-autogen, elixir-format
 msgid "Top songs"
-msgstr ""
-
-#: lib/helheim_web/templates/page/front_page.html.eex:107
-#: lib/helheim_web/templates/song/index.html.eex:1
-#, elixir-autogen, elixir-format
-msgid "Top songs this week"
-msgstr ""
-
-#: lib/helheim_web/templates/page/front_page.html.eex:95
-#, elixir-autogen, elixir-format
-msgid "Top songs today"
 msgstr ""
 
 #: lib/helheim_web/templates/preference/edit.html.eex:69
@@ -2788,7 +2771,7 @@ msgstr ""
 msgid "You can also delete your entire listening history from the site. This cannot be undone."
 msgstr ""
 
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:49
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:57
 #, elixir-autogen, elixir-format
 msgid "Your listening history has been deleted."
 msgstr ""
@@ -2803,7 +2786,7 @@ msgstr ""
 msgid "Remove my name from this song"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:48
+#: lib/helheim_web/controllers/song_controller.ex:73
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr ""
@@ -2874,18 +2857,37 @@ msgstr ""
 msgid "Your Last.fm account %{username} is connected and your listening history is shared on the site."
 msgstr ""
 
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:26
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:33
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:34
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:41
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your Last.fm account could not be connected. Please try again."
 msgstr ""
 
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:41
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:49
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your Last.fm account has been disconnected."
 msgstr ""
 
-#: lib/helheim_web/controllers/lastfm_account_controller.ex:21
+#: lib/helheim_web/controllers/lastfm_account_controller.ex:29
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your Last.fm account is now connected!"
+msgstr ""
+
+#: lib/helheim_web/templates/page/front_page.html.eex:100
+#: lib/helheim_web/templates/page/front_page.html.eex:115
+#: lib/helheim_web/templates/song/top.html.eex:6
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No songs have been listened to in this period yet..."
+msgstr ""
+
+#: lib/helheim_web/controllers/song_controller.ex:24
+#: lib/helheim_web/templates/page/front_page.html.eex:96
+#, elixir-autogen, elixir-format
+msgid "Top songs, past 24 hours"
+msgstr ""
+
+#: lib/helheim_web/controllers/song_controller.ex:28
+#: lib/helheim_web/templates/page/front_page.html.eex:111
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Top songs, past 7 days"
 msgstr ""

--- a/test/helheim/music/charts_test.exs
+++ b/test/helheim/music/charts_test.exs
@@ -38,24 +38,31 @@ defmodule Helheim.Music.ChartsTest do
     end
   end
 
-  describe "start_of_day/0" do
-    test "is midnight in Copenhagen expressed in UTC" do
-      start_of_day = Charts.start_of_day()
-      local = Timex.Timezone.convert(start_of_day, "Europe/Copenhagen")
-      assert local.hour == 0
-      assert local.minute == 0
-      assert Timex.before?(start_of_day, Timex.now())
-      assert Timex.diff(Timex.now(), start_of_day, :hours) < 25
+  describe "top_songs_last_day/2" do
+    test "includes listens from the past 24 hours and excludes older ones" do
+      song = insert(:song)
+      insert(:song_listen, song: song, played_at: Timex.shift(Timex.now, hours: -23))
+      old_song = insert(:song)
+      insert(:song_listen, song: old_song, played_at: Timex.shift(Timex.now, hours: -25))
+
+      results = Charts.top_songs_last_day(10)
+
+      assert [{top_song, 1}] = results
+      assert top_song.id == song.id
     end
   end
 
-  describe "start_of_week/0" do
-    test "is monday midnight in Copenhagen expressed in UTC" do
-      start_of_week = Charts.start_of_week()
-      local = Timex.Timezone.convert(start_of_week, "Europe/Copenhagen")
-      assert Timex.weekday(local) == 1
-      assert local.hour == 0
-      assert Timex.before?(start_of_week, Timex.now())
+  describe "top_songs_last_week/2" do
+    test "includes listens from the past 7 days and excludes older ones" do
+      song = insert(:song)
+      insert(:song_listen, song: song, played_at: Timex.shift(Timex.now, days: -6))
+      old_song = insert(:song)
+      insert(:song_listen, song: old_song, played_at: Timex.shift(Timex.now, days: -8))
+
+      results = Charts.top_songs_last_week(10)
+
+      assert [{top_song, 1}] = results
+      assert top_song.id == song.id
     end
   end
 end

--- a/test/helheim_web/controllers/page_controller_test.exs
+++ b/test/helheim_web/controllers/page_controller_test.exs
@@ -44,14 +44,27 @@ defmodule HelheimWeb.PageControllerTest do
       refute html_response(conn, 200) =~ gettext("Recent listens")
     end
 
-    test "it shows the top songs of today and this week", %{conn: conn} do
+    test "it shows the top songs of the past 24 hours and past 7 days", %{conn: conn} do
       song = insert(:song, title: "Orion")
       insert_list(2, :song_listen, song: song)
 
       conn = get conn, "/front_page"
       response = html_response(conn, 200)
-      assert response =~ gettext("Top songs today")
-      assert response =~ gettext("Top songs this week")
+      assert response =~ gettext("Top songs, past 24 hours")
+      assert response =~ gettext("Top songs, past 7 days")
+    end
+
+    test "it does not show the same song twice in the recent listens", %{conn: conn} do
+      user = insert(:user)
+      song = insert(:song, title: "Orion")
+      insert(:song_listen, user: user, song: song, played_at: Timex.shift(Timex.now, minutes: -10))
+      insert(:song_listen, user: user, song: song, played_at: Timex.shift(Timex.now, minutes: -5))
+
+      conn = get conn, "/front_page"
+      response = html_response(conn, 200)
+      [_before, after_recent] = String.split(response, gettext("Recent listens"), parts: 2)
+      [recent_section, _rest] = String.split(after_recent, gettext("Top songs, past 24 hours"), parts: 2)
+      assert length(String.split(recent_section, "Orion")) == 2
     end
   end
 

--- a/test/helheim_web/controllers/song_controller_test.exs
+++ b/test/helheim_web/controllers/song_controller_test.exs
@@ -2,31 +2,108 @@ defmodule HelheimWeb.SongControllerTest do
   use HelheimWeb.ConnCase
 
   ##############################################################################
-  # index/2
-  describe "index/2 when signed in" do
+  # recent/2
+  describe "recent/2 when signed in" do
     setup [:create_and_sign_in_user]
 
-    test "it returns a successful response with the top songs of the week", %{conn: conn} do
+    test "it shows the most recent listens with the listener", %{conn: conn} do
+      listener = insert(:user, username: "melomaniac")
+      insert(:song_listen, user: listener, song: insert(:song, title: "Creeping Death"))
+
+      conn = get conn, "/songs/recent"
+      response = html_response(conn, 200)
+      assert response =~ "Creeping Death"
+      assert response =~ "melomaniac"
+    end
+
+    test "it only shows the most recent listen of a song played on repeat", %{conn: conn} do
+      user = insert(:user)
       song = insert(:song, title: "Creeping Death")
+      insert(:song_listen, user: user, song: song, played_at: Timex.shift(Timex.now, minutes: -10))
+      insert(:song_listen, user: user, song: song, played_at: Timex.shift(Timex.now, minutes: -5))
+
+      conn = get conn, "/songs/recent"
+      response = html_response(conn, 200)
+      assert length(String.split(response, "Creeping Death")) == 2
+    end
+
+    test "it does not show listens from ignored users", %{conn: conn, user: user} do
+      ignoree = insert(:user)
+      insert(:ignore, ignorer: user, ignoree: ignoree, enabled: true)
+      insert(:song_listen, user: ignoree, song: insert(:song, title: "Creeping Death"))
+
+      conn = get conn, "/songs/recent"
+      refute html_response(conn, 200) =~ "Creeping Death"
+    end
+
+    test "it clamps the page number to the pagination cap", %{conn: conn} do
+      insert(:song_listen)
+      conn = get conn, "/songs/recent", %{"page" => "999"}
+      assert html_response(conn, 200)
+    end
+
+    test "it renders a placeholder when a song has no cover art", %{conn: conn} do
+      song = insert(:song, cover_image_url_small: nil)
       insert(:song_listen, song: song)
 
-      conn = get conn, "/songs"
+      conn = get conn, "/songs/recent"
+      assert html_response(conn, 200) =~ "song-cover-placeholder"
+    end
+  end
+
+  describe "recent/2 when not signed in" do
+    test "it redirects to the sign in page", %{conn: conn} do
+      conn = get conn, "/songs/recent"
+      assert redirected_to(conn) =~ session_path(conn, :new)
+    end
+  end
+
+  ##############################################################################
+  # top_day/2 + top_week/2
+  describe "top_day/2 when signed in" do
+    setup [:create_and_sign_in_user]
+
+    test "it shows songs listened to within the past 24 hours", %{conn: conn} do
+      song = insert(:song, title: "Creeping Death")
+      insert(:song_listen, song: song, played_at: Timex.shift(Timex.now, hours: -23))
+
+      conn = get conn, "/songs/top/day"
       assert html_response(conn, 200) =~ "Creeping Death"
     end
 
-    test "it does not include songs only listened to before this week", %{conn: conn} do
+    test "it does not include songs only listened to more than 24 hours ago", %{conn: conn} do
       song = insert(:song, title: "Creeping Death")
-      insert(:song_listen, song: song, played_at: Timex.shift(Timex.now, days: -8))
+      insert(:song_listen, song: song, played_at: Timex.shift(Timex.now, hours: -25))
 
-      conn = get conn, "/songs"
+      conn = get conn, "/songs/top/day"
       refute html_response(conn, 200) =~ "Creeping Death"
     end
   end
 
-  describe "index/2 when not signed in" do
-    test "it redirects to the sign in page", %{conn: conn} do
-      conn = get conn, "/songs"
-      assert redirected_to(conn) =~ session_path(conn, :new)
+  describe "top_week/2 when signed in" do
+    setup [:create_and_sign_in_user]
+
+    test "it shows songs listened to within the past 7 days", %{conn: conn} do
+      song = insert(:song, title: "Creeping Death")
+      insert(:song_listen, song: song, played_at: Timex.shift(Timex.now, days: -6))
+
+      conn = get conn, "/songs/top/week"
+      assert html_response(conn, 200) =~ "Creeping Death"
+    end
+
+    test "it does not include songs only listened to more than 7 days ago", %{conn: conn} do
+      song = insert(:song, title: "Creeping Death")
+      insert(:song_listen, song: song, played_at: Timex.shift(Timex.now, days: -8))
+
+      conn = get conn, "/songs/top/week"
+      refute html_response(conn, 200) =~ "Creeping Death"
+    end
+  end
+
+  describe "top_day/2 and top_week/2 when not signed in" do
+    test "they redirect to the sign in page", %{conn: conn} do
+      assert redirected_to(get(conn, "/songs/top/day")) =~ session_path(conn, :new)
+      assert redirected_to(get(build_conn(), "/songs/top/week")) =~ session_path(conn, :new)
     end
   end
 


### PR DESCRIPTION
## What

Follow-ups to the Last.fm listening history feature based on how it looks with real data:

- **Recent listens trimmed to 5** entries, matching the two top-5 chart cards.
- **Deduplicated recent listens**: a song played on repeat now appears only once (the newest listen), both on the front page and the full recent-listens page. Implemented with `DISTINCT ON (song_id)` via `SongListen.latest_per_song/1`.
- **Placeholder cover art**: songs without album art get a music-note placeholder box (same 64px footprint), so titles and artists stay aligned with neighboring entries instead of shifting left. The cover markup is now a shared `_cover.html.eex` partial.
- **Rolling chart windows**: "top songs today / this week" became "past 24 hours / past 7 days". As a bonus this removes the Copenhagen-midnight boundary logic — rolling windows are timezone-independent.
- **A full page per list**, each linked from its card's "Show All" button:
  - `/songs/recent` — deduplicated recent listens
  - `/songs/top/day` — past 24 hours
  - `/songs/top/week` — past 7 days
  
  This replaces the old `/songs` index (the recent-listens card previously linked there, which showed the weekly chart instead). All three pages are paginated and **capped at 100 pages**: the page param is clamped and `total_pages` is capped so pagination links never lead deeper.

## Testing

Full suite green (1516 tests). New coverage: dedupe behavior (front page + recent page), rolling window boundaries (23h/25h and 6d/8d), placeholder rendering, ignoree filtering on the recent page, and page-clamp behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)