### PR TITLE
Enrich songs and artists with metadata from MusicBrainz, fanart.tv and Deezer

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -42,7 +42,7 @@ config :helheim, Helheim.Auth.Guardian,
 config :helheim, Oban,
   engine: Oban.Engines.Basic,
   repo: Helheim.Repo,
-  queues: [lastfm: 5],
+  queues: [lastfm: 5, enrichment: 1],
   plugins: [
     {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
     {Oban.Plugins.Cron,

--- a/config/config.exs
+++ b/config/config.exs
@@ -47,7 +47,8 @@ config :helheim, Oban,
     {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
     {Oban.Plugins.Cron,
      crontab: [
-       {"*/5 * * * *", Helheim.Lastfm.SchedulerWorker}
+       {"*/5 * * * *", Helheim.Lastfm.SchedulerWorker},
+       {"30 * * * *", Helheim.Music.EnrichmentSweepWorker}
      ]}
   ]
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -51,6 +51,10 @@ config :helheim, Oban,
      ]}
   ]
 
+# Configure MusicBrainz (identifying User-Agent required by their API terms)
+config :helheim, :musicbrainz,
+  user_agent: "Helheim/1.0 (https://www.helheim.dk; thomas@visioneers.dk)"
+
 # Configure Sentry
 config :sentry,
   environment_name: config_env()

--- a/config/dev.secret.exs.example
+++ b/config/dev.secret.exs.example
@@ -28,6 +28,12 @@ config :helheim, :lastfm,
   api_key: "LASTFM_API_KEY",
   shared_secret: "LASTFM_SHARED_SECRET"
 
+# Optional: artist images from fanart.tv (register at
+# https://fanart.tv/get-an-api-key/). Without a key, artist images fall
+# back to the Deezer API, which needs no key.
+# config :helheim, :fanart,
+#   api_key: "FANART_API_KEY"
+
 # Optional: use the "dev" branch of the Neon database instead of the local
 # postgres server configured in dev.exs. Fetch the connection string with:
 #   neonctl connection-string dev --project-id white-cell-654660 --role-name helheim --database-name helheim_prod

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -67,4 +67,7 @@ if config_env() == :prod do
   config :helheim, :lastfm,
     api_key: System.get_env("LASTFM_API_KEY"),
     shared_secret: System.get_env("LASTFM_SHARED_SECRET")
+
+  config :helheim, :fanart,
+    api_key: System.get_env("FANART_API_KEY")
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -63,6 +63,10 @@ config :helheim, :lastfm,
   api_key: "lastfm_test_api_key",
   shared_secret: "lastfm_test_shared_secret"
 
+# Configure fanart.tv
+config :helheim, :fanart,
+  api_key: "fanart_test_api_key"
+
 # Configure wallaby
 config :wallaby,
   otp_app: :helheim,

--- a/config/test.exs
+++ b/config/test.exs
@@ -18,6 +18,9 @@ config :helheim, Oban, testing: :manual
 # Never serve stale chart data across tests
 config :helheim, :chart_cache_ttl_ms, 0
 
+# Never cache external API responses across tests
+config :helheim, :api_cache_ttl_ms, 0
+
 # Print only warnings and errors during test
 config :logger, level: :warning
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -67,6 +67,11 @@ config :helheim, :lastfm,
 config :helheim, :fanart,
   api_key: "fanart_test_api_key"
 
+# Don't pace MusicBrainz calls in tests (clients are mocked)
+config :helheim, :musicbrainz,
+  user_agent: "Helheim test",
+  pause_ms: 0
+
 # Configure wallaby
 config :wallaby,
   otp_app: :helheim,

--- a/lib/helheim/cache.ex
+++ b/lib/helheim/cache.ex
@@ -20,17 +20,19 @@ defmodule Helheim.Cache do
 
   @doc """
   Returns the cached value for `key`, or computes it with `fun` and caches
-  it for `ttl_ms`. A ttl of 0 (or less) bypasses the cache entirely.
+  it for `ttl_ms`. A ttl of 0 (or less) bypasses the cache entirely. The
+  optional `:cache_if` predicate decides whether a computed value is worth
+  caching - e.g. to avoid pinning transient API errors for the whole ttl.
   """
-  def fetch(key, ttl_ms, fun) when is_integer(ttl_ms) do
+  def fetch(key, ttl_ms, fun, opts \\ []) when is_integer(ttl_ms) do
     if ttl_ms > 0 do
-      lookup(key, fun, ttl_ms)
+      lookup(key, fun, ttl_ms, Keyword.get(opts, :cache_if, fn _value -> true end))
     else
       fun.()
     end
   end
 
-  defp lookup(key, fun, ttl_ms) do
+  defp lookup(key, fun, ttl_ms, cache_if) do
     now = System.monotonic_time(:millisecond)
 
     case :ets.lookup(@table, key) do
@@ -38,7 +40,7 @@ defmodule Helheim.Cache do
         value
       _ ->
         value = fun.()
-        :ets.insert(@table, {key, value, now + ttl_ms})
+        if cache_if.(value), do: :ets.insert(@table, {key, value, now + ttl_ms})
         value
     end
   end

--- a/lib/helheim/deezer/client.ex
+++ b/lib/helheim/deezer/client.ex
@@ -1,0 +1,43 @@
+defmodule Helheim.Deezer.Client do
+  @moduledoc """
+  Thin Req based client for Deezer's public API (no authentication), used
+  as the fallback source for artist images when fanart.tv has none.
+  """
+
+  @api_url "https://api.deezer.com"
+
+  @doc """
+  Searches for the artist by name and returns its images, but only when a
+  result matches the name case-insensitively - a fuzzy match would risk
+  showing the wrong artist's photo.
+  """
+  def search_artist(name) do
+    case Req.get("#{@api_url}/search/artist", params: %{q: name}) do
+      {:ok, %Req.Response{body: %{"error" => %{"code" => 4}}}} ->
+        {:error, :rate_limited}
+      {:ok, %Req.Response{body: %{"error" => error}}} ->
+        {:error, {:api_error, error["code"], error["message"]}}
+      {:ok, %Req.Response{status: 200, body: %{"data" => data}}} when is_list(data) ->
+        find_exact_match(data, name)
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error, {:http_error, status, body}}
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp find_exact_match(data, name) do
+    data
+    |> Enum.find(fn artist -> String.downcase(artist["name"] || "") == String.downcase(name) end)
+    |> case do
+      nil ->
+        {:error, :not_found}
+      artist ->
+        {:ok, %{
+          image_url_small: artist["picture_small"],
+          image_url_medium: artist["picture_medium"],
+          image_url_large: artist["picture_xl"]
+        }}
+    end
+  end
+end

--- a/lib/helheim/deezer/client.ex
+++ b/lib/helheim/deezer/client.ex
@@ -34,10 +34,13 @@ defmodule Helheim.Deezer.Client do
         {:error, :not_found}
       artist ->
         {:ok, %{
-          image_url_small: artist["picture_small"],
-          image_url_medium: artist["picture_medium"],
-          image_url_large: artist["picture_xl"]
+          image_url_small: present_url(artist["picture_small"]),
+          image_url_medium: present_url(artist["picture_medium"]),
+          image_url_large: present_url(artist["picture_xl"])
         }}
     end
   end
+
+  defp present_url(url) when is_binary(url) and url != "", do: url
+  defp present_url(_), do: nil
 end

--- a/lib/helheim/fanart/client.ex
+++ b/lib/helheim/fanart/client.ex
@@ -21,8 +21,12 @@ defmodule Helheim.Fanart.Client do
   defp fetch_images(mbid, api_key) do
     case Req.get("#{@api_url}/#{mbid}", params: %{api_key: api_key}) do
       {:ok, %Req.Response{status: 200, body: %{"artistthumb" => [_ | _] = thumbs}}} ->
-        best = Enum.max_by(thumbs, &likes/1)
-        {:ok, %{thumb_url: best["url"], preview_url: preview_url(best["url"])}}
+        case Enum.max_by(thumbs, &likes/1) do
+          %{"url" => url} when is_binary(url) and url != "" ->
+            {:ok, %{thumb_url: url, preview_url: preview_url(url)}}
+          _ ->
+            {:error, :not_found}
+        end
       {:ok, %Req.Response{status: 200, body: _no_thumbs}} ->
         {:error, :not_found}
       {:ok, %Req.Response{status: 404}} ->

--- a/lib/helheim/fanart/client.ex
+++ b/lib/helheim/fanart/client.ex
@@ -1,0 +1,50 @@
+defmodule Helheim.Fanart.Client do
+  @moduledoc """
+  Thin Req based client for fanart.tv, used to fetch artist images by
+  MusicBrainz artist id. Returns `{:error, :not_configured}` when no API
+  key is set so callers can fall back to other image sources.
+  """
+
+  @api_url "https://webservice.fanart.tv/v3/music"
+
+  @doc """
+  Returns the highest voted artist thumb for the artist, both as the full
+  size (1000px) url and as fanart's ~200px preview rendition.
+  """
+  def artist_images(mbid) do
+    case config()[:api_key] do
+      key when is_binary(key) and key != "" -> fetch_images(mbid, key)
+      _ -> {:error, :not_configured}
+    end
+  end
+
+  defp fetch_images(mbid, api_key) do
+    case Req.get("#{@api_url}/#{mbid}", params: %{api_key: api_key}) do
+      {:ok, %Req.Response{status: 200, body: %{"artistthumb" => [_ | _] = thumbs}}} ->
+        best = Enum.max_by(thumbs, &likes/1)
+        {:ok, %{thumb_url: best["url"], preview_url: preview_url(best["url"])}}
+      {:ok, %Req.Response{status: 200, body: _no_thumbs}} ->
+        {:error, :not_found}
+      {:ok, %Req.Response{status: 404}} ->
+        {:error, :not_found}
+      {:ok, %Req.Response{status: 429}} ->
+        {:error, :rate_limited}
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error, {:http_error, status, body}}
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp likes(thumb) do
+    case Integer.parse("#{thumb["likes"]}") do
+      {likes, ""} -> likes
+      _ -> 0
+    end
+  end
+
+  defp preview_url(nil), do: nil
+  defp preview_url(url), do: String.replace(url, "/fanart/", "/preview/")
+
+  defp config, do: Application.get_env(:helheim, :fanart, [])
+end

--- a/lib/helheim/lastfm/client.ex
+++ b/lib/helheim/lastfm/client.ex
@@ -9,6 +9,8 @@ defmodule Helheim.Lastfm.Client do
   before statuses.
   """
 
+  alias Helheim.Lastfm.Payload
+
   @auth_url "https://www.last.fm/api/auth/"
   @api_url "https://ws.audioscrobbler.com/2.0/"
 
@@ -108,7 +110,7 @@ defmodule Helheim.Lastfm.Client do
 
     case api_get(params) do
       {:ok, %{"artist" => artist}} ->
-        {:ok, %{mbid: blank_to_nil(artist["mbid"]), url: blank_to_nil(artist["url"]), tags: parse_artist_tags(artist)}}
+        {:ok, %{mbid: Payload.blank_to_nil(artist["mbid"]), url: Payload.blank_to_nil(artist["url"]), tags: Payload.tag_names(artist["tags"])}}
       {:ok, body} ->
         {:error, {:unexpected_response, body}}
       {:error, :user_not_found} ->
@@ -118,35 +120,19 @@ defmodule Helheim.Lastfm.Client do
     end
   end
 
-  defp parse_artist_tags(artist) do
-    case get_in(artist, ["tags", "tag"]) do
-      tags when is_list(tags) -> tags |> Enum.map(& &1["name"]) |> Enum.reject(&is_nil/1)
-      %{"name" => name} -> [name]
-      _ -> []
-    end
-  end
-
   defp parse_track_info(track) do
-    album = track["album"] || %{}
+    album = if is_map(track["album"]), do: track["album"], else: %{}
 
     %{
-      mbid: blank_to_nil(track["mbid"]),
-      artist_mbid: blank_to_nil(get_in_map(track, "artist", "mbid")),
-      album_mbid: blank_to_nil(album["mbid"]),
-      album_name: blank_to_nil(album["title"]),
+      mbid: Payload.blank_to_nil(track["mbid"]),
+      artist_mbid: Payload.blank_to_nil(get_in_map(track, "artist", "mbid")),
+      album_mbid: Payload.blank_to_nil(album["mbid"]),
+      album_name: Payload.blank_to_nil(album["title"]),
       duration_seconds: parse_duration(track["duration"]),
-      image_extralarge: image_url(album["image"], "extralarge"),
-      tags: parse_tags(track),
-      url: blank_to_nil(track["url"])
+      image_extralarge: Payload.image_url(album["image"], "extralarge"),
+      tags: Payload.tag_names(track["toptags"]),
+      url: Payload.blank_to_nil(track["url"])
     }
-  end
-
-  defp parse_tags(track) do
-    case get_in(track, ["toptags", "tag"]) do
-      tags when is_list(tags) -> tags |> Enum.map(& &1["name"]) |> Enum.reject(&is_nil/1)
-      %{"name" => name} -> [name]
-      _ -> []
-    end
   end
 
   # track.getInfo reports the duration in milliseconds, as a string, and
@@ -164,19 +150,6 @@ defmodule Helheim.Lastfm.Client do
       _ -> nil
     end
   end
-
-  defp image_url(images, size) when is_list(images) do
-    images
-    |> Enum.find(fn image -> is_map(image) && image["size"] == size end)
-    |> case do
-      %{"#text" => url} when is_binary(url) and url != "" -> url
-      _ -> nil
-    end
-  end
-  defp image_url(_, _), do: nil
-
-  defp blank_to_nil(value) when is_binary(value) and value != "", do: value
-  defp blank_to_nil(_), do: nil
 
   # Signs the params with the api_sig required for authenticated calls:
   # md5 over the alphabetically sorted "<name><value>" pairs plus the shared

--- a/lib/helheim/lastfm/client.ex
+++ b/lib/helheim/lastfm/client.ex
@@ -108,13 +108,21 @@ defmodule Helheim.Lastfm.Client do
 
     case api_get(params) do
       {:ok, %{"artist" => artist}} ->
-        {:ok, %{mbid: blank_to_nil(artist["mbid"]), url: blank_to_nil(artist["url"])}}
+        {:ok, %{mbid: blank_to_nil(artist["mbid"]), url: blank_to_nil(artist["url"]), tags: parse_artist_tags(artist)}}
       {:ok, body} ->
         {:error, {:unexpected_response, body}}
       {:error, :user_not_found} ->
         {:error, :not_found}
       error ->
         error
+    end
+  end
+
+  defp parse_artist_tags(artist) do
+    case get_in(artist, ["tags", "tag"]) do
+      tags when is_list(tags) -> tags |> Enum.map(& &1["name"]) |> Enum.reject(&is_nil/1)
+      %{"name" => name} -> [name]
+      _ -> []
     end
   end
 

--- a/lib/helheim/lastfm/client.ex
+++ b/lib/helheim/lastfm/client.ex
@@ -69,6 +69,107 @@ defmodule Helheim.Lastfm.Client do
     end
   end
 
+  @doc """
+  Fetches extended metadata for a track: MusicBrainz ids, duration, album
+  details and the top tags. Unsigned call; autocorrect follows Last.fm's
+  canonical spelling of the artist/track.
+  """
+  def track_info(artist, title) do
+    params = %{
+      method: "track.getInfo",
+      api_key: config()[:api_key],
+      artist: artist,
+      track: title,
+      autocorrect: 1,
+      format: "json"
+    }
+
+    case api_get(params) do
+      {:ok, %{"track" => track}} -> {:ok, parse_track_info(track)}
+      {:ok, body} -> {:error, {:unexpected_response, body}}
+      {:error, :user_not_found} -> {:error, :not_found}
+      error -> error
+    end
+  end
+
+  @doc """
+  Fetches an artist's MusicBrainz id and Last.fm url. The image data the
+  endpoint returns is deliberately ignored - it has been a placeholder for
+  all artists since 2019.
+  """
+  def artist_info(name) do
+    params = %{
+      method: "artist.getInfo",
+      api_key: config()[:api_key],
+      artist: name,
+      autocorrect: 1,
+      format: "json"
+    }
+
+    case api_get(params) do
+      {:ok, %{"artist" => artist}} ->
+        {:ok, %{mbid: blank_to_nil(artist["mbid"]), url: blank_to_nil(artist["url"])}}
+      {:ok, body} ->
+        {:error, {:unexpected_response, body}}
+      {:error, :user_not_found} ->
+        {:error, :not_found}
+      error ->
+        error
+    end
+  end
+
+  defp parse_track_info(track) do
+    album = track["album"] || %{}
+
+    %{
+      mbid: blank_to_nil(track["mbid"]),
+      artist_mbid: blank_to_nil(get_in_map(track, "artist", "mbid")),
+      album_mbid: blank_to_nil(album["mbid"]),
+      album_name: blank_to_nil(album["title"]),
+      duration_seconds: parse_duration(track["duration"]),
+      image_extralarge: image_url(album["image"], "extralarge"),
+      tags: parse_tags(track),
+      url: blank_to_nil(track["url"])
+    }
+  end
+
+  defp parse_tags(track) do
+    case get_in(track, ["toptags", "tag"]) do
+      tags when is_list(tags) -> tags |> Enum.map(& &1["name"]) |> Enum.reject(&is_nil/1)
+      %{"name" => name} -> [name]
+      _ -> []
+    end
+  end
+
+  # track.getInfo reports the duration in milliseconds, as a string, and
+  # very often as "0" when unknown.
+  defp parse_duration(duration) do
+    case Integer.parse("#{duration}") do
+      {ms, ""} when ms > 0 -> div(ms, 1000)
+      _ -> nil
+    end
+  end
+
+  defp get_in_map(map, key1, key2) do
+    case map[key1] do
+      %{} = inner -> inner[key2]
+      _ -> nil
+    end
+  end
+
+  defp image_url(images, size) when is_list(images) do
+    images
+    |> Enum.find(fn image -> is_map(image) && image["size"] == size end)
+    |> case do
+      %{"#text" => url} when is_binary(url) and url != "" -> url
+      _ -> nil
+    end
+  end
+  defp image_url(_, _), do: nil
+
+  defp blank_to_nil(value) when is_binary(value) and value != "", do: value
+  defp blank_to_nil(_), do: nil
+
   # Signs the params with the api_sig required for authenticated calls:
   # md5 over the alphabetically sorted "<name><value>" pairs plus the shared
   # secret. The format param must not be part of the signature.

--- a/lib/helheim/lastfm/payload.ex
+++ b/lib/helheim/lastfm/payload.ex
@@ -1,0 +1,48 @@
+defmodule Helheim.Lastfm.Payload do
+  @moduledoc """
+  Shared parsing helpers for Last.fm API payloads, used by both the scrobble
+  sync and the metadata enrichment paths so the two can never drift apart
+  (e.g. one filtering the placeholder artwork and the other not).
+  """
+
+  # The image Last.fm serves when it has no real artwork.
+  @placeholder_image_hash "2a96cbd8b46e442fc41c2b86b821562f"
+
+  @doc """
+  Picks the url of the image with the given size out of a Last.fm image
+  array. Blank urls and the placeholder-star artwork count as no image.
+  """
+  def image_url(images, size) when is_list(images) do
+    images
+    |> Enum.find(fn image -> is_map(image) && image["size"] == size end)
+    |> case do
+      %{"#text" => url} when is_binary(url) -> url |> blank_to_nil() |> reject_placeholder()
+      _ -> nil
+    end
+  end
+  def image_url(_, _), do: nil
+
+  @doc """
+  Extracts tag names from a Last.fm tag container (`toptags` on tracks,
+  `tags` on artists). Defensive against the API's inconsistent empty-value
+  serializations (missing key, empty string, bare object).
+  """
+  def tag_names(%{"tag" => tags}) when is_list(tags) do
+    tags
+    |> Enum.map(fn
+      %{"name" => name} -> name
+      _ -> nil
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+  def tag_names(%{"tag" => %{"name" => name}}), do: [name]
+  def tag_names(_), do: []
+
+  def blank_to_nil(value) when is_binary(value) and value != "", do: value
+  def blank_to_nil(_), do: nil
+
+  defp reject_placeholder(nil), do: nil
+  defp reject_placeholder(url) do
+    if String.contains?(url, @placeholder_image_hash), do: nil, else: url
+  end
+end

--- a/lib/helheim/lastfm/sync_service.ex
+++ b/lib/helheim/lastfm/sync_service.ex
@@ -16,6 +16,7 @@ defmodule Helheim.Lastfm.SyncService do
   alias Helheim.Song
   alias Helheim.SongListen
   alias Helheim.LastfmAccount
+  alias Helheim.Music.SongEnrichmentWorker
 
   # The image Last.fm serves when it has no album art.
   @placeholder_image_hash "2a96cbd8b46e442fc41c2b86b821562f"
@@ -32,16 +33,39 @@ defmodule Helheim.Lastfm.SyncService do
     |> Multi.run(:listens, fn repo, _changes -> insert_listens(repo, account, parsed_items) end)
     |> Multi.run(:account, fn repo, _changes -> update_account(repo, account, parsed_items) end)
     |> Repo.transaction(timeout: @sync_timeout)
+    |> case do
+      {:ok, %{listens: %{song_ids: song_ids}}} = result ->
+        enqueue_enrichment(song_ids)
+        result
+      other ->
+        other
+    end
   end
 
   defp insert_listens(repo, account, parsed_items) do
-    listens =
-      Enum.map(parsed_items, fn {song_attrs, played_at} ->
+    {listens, song_ids} =
+      Enum.map_reduce(parsed_items, MapSet.new(), fn {song_attrs, played_at}, song_ids ->
         song = upsert_song!(repo, song_attrs)
-        insert_listen!(repo, account.user_id, song, played_at)
+        {insert_listen!(repo, account.user_id, song, played_at), MapSet.put(song_ids, song.id)}
       end)
 
-    {:ok, Enum.reject(listens, &is_nil/1)}
+    {:ok, %{listens: Enum.reject(listens, &is_nil/1), song_ids: MapSet.to_list(song_ids)}}
+  end
+
+  # Songs that have not been enriched yet (typically the ones this batch
+  # created) get an enrichment job; job uniqueness dedupes across polls.
+  defp enqueue_enrichment([]), do: :ok
+  defp enqueue_enrichment(song_ids) do
+    Song
+    |> Song.unenriched()
+    |> where([s], s.id in ^song_ids)
+    |> select([s], s.id)
+    |> Repo.all()
+    |> Enum.each(fn song_id ->
+      %{song_id: song_id}
+      |> SongEnrichmentWorker.new()
+      |> Oban.insert()
+    end)
   end
 
   # Songs are identified by lower(artist_name) + lower(title). On conflict
@@ -58,6 +82,9 @@ defmodule Helheim.Lastfm.SyncService do
           cover_image_url: fragment("COALESCE(EXCLUDED.cover_image_url, ?)", s.cover_image_url),
           cover_image_url_small: fragment("COALESCE(EXCLUDED.cover_image_url_small, ?)", s.cover_image_url_small),
           lastfm_track_url: fragment("COALESCE(EXCLUDED.lastfm_track_url, ?)", s.lastfm_track_url),
+          mbid: fragment("COALESCE(EXCLUDED.mbid, ?)", s.mbid),
+          artist_mbid: fragment("COALESCE(EXCLUDED.artist_mbid, ?)", s.artist_mbid),
+          album_mbid: fragment("COALESCE(EXCLUDED.album_mbid, ?)", s.album_mbid),
           updated_at: fragment("EXCLUDED.updated_at")
         ]]
 
@@ -133,9 +160,15 @@ defmodule Helheim.Lastfm.SyncService do
       album_name: album_name(track),
       cover_image_url: image_url(track["image"], "extralarge"),
       cover_image_url_small: image_url(track["image"], "medium"),
-      lastfm_track_url: blank_to_nil(track["url"])
+      lastfm_track_url: blank_to_nil(track["url"]),
+      mbid: blank_to_nil(track["mbid"]),
+      artist_mbid: mbid_of(track["artist"]),
+      album_mbid: mbid_of(track["album"])
     }
   end
+
+  defp mbid_of(%{"mbid" => mbid}), do: blank_to_nil(mbid)
+  defp mbid_of(_), do: nil
 
   defp image_url(images, size) when is_list(images) do
     images

--- a/lib/helheim/lastfm/sync_service.ex
+++ b/lib/helheim/lastfm/sync_service.ex
@@ -16,10 +16,10 @@ defmodule Helheim.Lastfm.SyncService do
   alias Helheim.Song
   alias Helheim.SongListen
   alias Helheim.LastfmAccount
+  alias Helheim.Lastfm.Payload
   alias Helheim.Music.SongEnrichmentWorker
 
-  # The image Last.fm serves when it has no album art.
-  @placeholder_image_hash "2a96cbd8b46e442fc41c2b86b821562f"
+  require Logger
 
   # A full page of 200 scrobbles is several hundred queries in one
   # transaction; against a remote database (Neon) that far exceeds the
@@ -54,6 +54,9 @@ defmodule Helheim.Lastfm.SyncService do
 
   # Songs that have not been enriched yet (typically the ones this batch
   # created) get an enrichment job; job uniqueness dedupes across polls.
+  # Failures are logged rather than raised: the listens are already
+  # committed, so a broken enqueue must not fail the poll - the hourly
+  # enrichment sweep picks up anything missed here.
   defp enqueue_enrichment([]), do: :ok
   defp enqueue_enrichment(song_ids) do
     Song
@@ -66,6 +69,8 @@ defmodule Helheim.Lastfm.SyncService do
       |> SongEnrichmentWorker.new()
       |> Oban.insert()
     end)
+  rescue
+    error -> Logger.error("Failed to enqueue song enrichment: #{Exception.message(error)}")
   end
 
   # Songs are identified by lower(artist_name) + lower(title). On conflict
@@ -150,7 +155,7 @@ defmodule Helheim.Lastfm.SyncService do
   defp artist_name(%{"artist" => %{} = artist}), do: artist["#text"] || artist["name"]
   defp artist_name(_), do: nil
 
-  defp album_name(%{"album" => %{"#text" => album}}), do: blank_to_nil(album)
+  defp album_name(%{"album" => %{"#text" => album}}), do: Payload.blank_to_nil(album)
   defp album_name(_), do: nil
 
   defp song_attrs(track, title, artist) do
@@ -158,33 +163,15 @@ defmodule Helheim.Lastfm.SyncService do
       title: title,
       artist_name: artist,
       album_name: album_name(track),
-      cover_image_url: image_url(track["image"], "extralarge"),
-      cover_image_url_small: image_url(track["image"], "medium"),
-      lastfm_track_url: blank_to_nil(track["url"]),
-      mbid: blank_to_nil(track["mbid"]),
+      cover_image_url: Payload.image_url(track["image"], "extralarge"),
+      cover_image_url_small: Payload.image_url(track["image"], "medium"),
+      lastfm_track_url: Payload.blank_to_nil(track["url"]),
+      mbid: Payload.blank_to_nil(track["mbid"]),
       artist_mbid: mbid_of(track["artist"]),
       album_mbid: mbid_of(track["album"])
     }
   end
 
-  defp mbid_of(%{"mbid" => mbid}), do: blank_to_nil(mbid)
+  defp mbid_of(%{"mbid" => mbid}), do: Payload.blank_to_nil(mbid)
   defp mbid_of(_), do: nil
-
-  defp image_url(images, size) when is_list(images) do
-    images
-    |> Enum.find(fn image -> is_map(image) && image["size"] == size end)
-    |> case do
-      %{"#text" => url} when is_binary(url) -> blank_to_nil(url) |> reject_placeholder()
-      _ -> nil
-    end
-  end
-  defp image_url(_, _), do: nil
-
-  defp reject_placeholder(nil), do: nil
-  defp reject_placeholder(url) do
-    if String.contains?(url, @placeholder_image_hash), do: nil, else: url
-  end
-
-  defp blank_to_nil(value) when is_binary(value) and value != "", do: value
-  defp blank_to_nil(_), do: nil
 end

--- a/lib/helheim/models/artist.ex
+++ b/lib/helheim/models/artist.ex
@@ -1,0 +1,51 @@
+defmodule Helheim.Artist do
+  use Helheim, :model
+
+  alias Helheim.Artist
+  alias Helheim.Repo
+
+  schema "artists" do
+    field :name,             :string
+    field :mbid,             :string
+    field :country_code,     :string
+    field :country_name,     :string
+    field :image_url_small,  :string
+    field :image_url_medium, :string
+    field :image_url_large,  :string
+    field :image_source,     :string
+    field :enriched_at,      :utc_datetime_usec
+    has_many :songs, Helheim.Song
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:name, :mbid, :country_code, :country_name, :image_url_small, :image_url_medium, :image_url_large, :image_source, :enriched_at])
+    |> validate_required([:name])
+    |> unique_constraint(:name, name: :artists_name_index)
+  end
+
+  @doc """
+  Finds or creates the artist with the given name, matching
+  case-insensitively - the same identity rule songs use for artist_name.
+  """
+  def get_or_create_by_name!(name) do
+    get_by_name(name) ||
+      %Artist{}
+      |> changeset(%{name: name})
+      |> Repo.insert!(on_conflict: :nothing, conflict_target: {:unsafe_fragment, "(lower(name))"})
+      |> case do
+        %Artist{id: nil} -> get_by_name(name)
+        artist -> artist
+      end
+  end
+
+  def get_by_name(name) do
+    Repo.one(from a in Artist, where: fragment("lower(?)", a.name) == ^String.downcase(name))
+  end
+
+  def by_names(query, names) do
+    downcased = Enum.map(names, &String.downcase/1)
+    from a in query, where: fragment("lower(?)", a.name) in ^downcased
+  end
+end

--- a/lib/helheim/models/artist.ex
+++ b/lib/helheim/models/artist.ex
@@ -2,7 +2,6 @@ defmodule Helheim.Artist do
   use Helheim, :model
 
   alias Helheim.Artist
-  alias Helheim.Repo
 
   schema "artists" do
     field :name,             :string
@@ -29,20 +28,9 @@ defmodule Helheim.Artist do
   Finds or creates the artist with the given name, matching
   case-insensitively - the same identity rule songs use for artist_name.
   """
-  def get_or_create_by_name!(name) do
-    get_by_name(name) ||
-      %Artist{}
-      |> changeset(%{name: name})
-      |> Repo.insert!(on_conflict: :nothing, conflict_target: {:unsafe_fragment, "(lower(name))"})
-      |> case do
-        %Artist{id: nil} -> get_by_name(name)
-        artist -> artist
-      end
-  end
+  def get_or_create_by_name!(name), do: Helheim.NamedLookup.get_or_create!(Artist, name)
 
-  def get_by_name(name) do
-    Repo.one(from a in Artist, where: fragment("lower(?)", a.name) == ^String.downcase(name))
-  end
+  def get_by_name(name), do: Helheim.NamedLookup.get(Artist, name)
 
   def by_names(query, names) do
     downcased = Enum.map(names, &String.downcase/1)

--- a/lib/helheim/models/song.ex
+++ b/lib/helheim/models/song.ex
@@ -9,21 +9,36 @@ defmodule Helheim.Song do
     field :album_name,            :string
     field :cover_image_url,       :string
     field :cover_image_url_small, :string
+    field :cover_image_url_large, :string
     field :lastfm_track_url,      :string
+    field :mbid,                  :string
+    field :artist_mbid,           :string
+    field :album_mbid,            :string
+    field :release_year,          :integer
+    field :duration_seconds,      :integer
+    field :enriched_at,           :utc_datetime_usec
     field :comment_count,         :integer
     field :listens_count,         :integer
+    belongs_to :artist, Helheim.Artist
     has_many :listens, SongListen
     has_many :comments, Helheim.Comment
+    has_many :song_tags, Helheim.SongTag
+    has_many :tags, through: [:song_tags, :tag]
     timestamps(type: :utc_datetime_usec)
   end
 
-  @metadata_fields [:album_name, :cover_image_url, :cover_image_url_small, :lastfm_track_url]
+  @metadata_fields [:album_name, :cover_image_url, :cover_image_url_small, :lastfm_track_url, :mbid, :artist_mbid, :album_mbid]
+  @enrichment_fields [:cover_image_url_large, :release_year, :duration_seconds, :enriched_at]
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:title, :artist_name | @metadata_fields])
+    |> cast(params, [:title, :artist_name | @metadata_fields ++ @enrichment_fields])
     |> validate_required([:title, :artist_name])
     |> unique_constraint(:title, name: :songs_artist_title_index)
+  end
+
+  def unenriched(query) do
+    from s in query, where: is_nil(s.enriched_at)
   end
 
   def top_by_listens_since(query, since, excluded_user_ids \\ nil)

--- a/lib/helheim/models/song_tag.ex
+++ b/lib/helheim/models/song_tag.ex
@@ -1,0 +1,20 @@
+defmodule Helheim.SongTag do
+  use Helheim, :model
+
+  schema "songs_tags" do
+    belongs_to :song, Helheim.Song
+    belongs_to :tag, Helheim.Tag
+    field :position, :integer
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:position])
+    |> validate_required([:position])
+  end
+
+  def ordered(query) do
+    from st in query, order_by: [asc: st.position]
+  end
+end

--- a/lib/helheim/models/tag.ex
+++ b/lib/helheim/models/tag.ex
@@ -1,7 +1,6 @@
 defmodule Helheim.Tag do
   use Helheim, :model
 
-  alias Helheim.Repo
   alias Helheim.Tag
 
   schema "tags" do
@@ -22,18 +21,7 @@ defmodule Helheim.Tag do
   @doc """
   Finds or creates the tag with the given name, matching case-insensitively.
   """
-  def get_or_create_by_name!(name) do
-    get_by_name(name) ||
-      %Tag{}
-      |> changeset(%{name: name})
-      |> Repo.insert!(on_conflict: :nothing, conflict_target: {:unsafe_fragment, "(lower(name))"})
-      |> case do
-        %Tag{id: nil} -> get_by_name(name)
-        tag -> tag
-      end
-  end
+  def get_or_create_by_name!(name), do: Helheim.NamedLookup.get_or_create!(Tag, name)
 
-  def get_by_name(name) do
-    Repo.one(from t in Tag, where: fragment("lower(?)", t.name) == ^String.downcase(name))
-  end
+  def get_by_name(name), do: Helheim.NamedLookup.get(Tag, name)
 end

--- a/lib/helheim/models/tag.ex
+++ b/lib/helheim/models/tag.ex
@@ -1,0 +1,39 @@
+defmodule Helheim.Tag do
+  use Helheim, :model
+
+  alias Helheim.Repo
+  alias Helheim.Tag
+
+  schema "tags" do
+    field :name, :string
+    has_many :song_tags, Helheim.SongTag
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:name])
+    |> trim_fields(:name)
+    |> validate_required([:name])
+    |> validate_length(:name, max: 40)
+    |> unique_constraint(:name, name: :tags_name_index)
+  end
+
+  @doc """
+  Finds or creates the tag with the given name, matching case-insensitively.
+  """
+  def get_or_create_by_name!(name) do
+    get_by_name(name) ||
+      %Tag{}
+      |> changeset(%{name: name})
+      |> Repo.insert!(on_conflict: :nothing, conflict_target: {:unsafe_fragment, "(lower(name))"})
+      |> case do
+        %Tag{id: nil} -> get_by_name(name)
+        tag -> tag
+      end
+  end
+
+  def get_by_name(name) do
+    Repo.one(from t in Tag, where: fragment("lower(?)", t.name) == ^String.downcase(name))
+  end
+end

--- a/lib/helheim/music/artist_enrichment_worker.ex
+++ b/lib/helheim/music/artist_enrichment_worker.ex
@@ -1,0 +1,152 @@
+defmodule Helheim.Music.ArtistEnrichmentWorker do
+  @moduledoc """
+  Enriches an artist with a MusicBrainz id, country (nationality) and
+  images. Images come from fanart.tv (by MusicBrainz id, community voted)
+  with Deezer as the fallback source when fanart has nothing.
+
+  Runs on the concurrency-1 :enrichment queue; see SongEnrichmentWorker
+  for the MusicBrainz pacing rationale.
+  """
+
+  use Oban.Worker,
+    queue: :enrichment,
+    max_attempts: 5,
+    unique: [period: 3600, keys: [:artist_id]]
+
+  alias Helheim.Repo
+  alias Helheim.Artist
+  alias Helheim.Lastfm
+  alias Helheim.Musicbrainz
+  alias Helheim.Fanart
+  alias Helheim.Deezer
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"artist_id" => artist_id} = args}) do
+    artist = Repo.get(Artist, artist_id)
+
+    cond do
+      is_nil(artist) -> :ok
+      artist.enriched_at && args["force"] != true -> :ok
+      true -> enrich(artist)
+    end
+  end
+
+  defp enrich(artist) do
+    with {:ok, artist} <- resolve_mbid(artist),
+         {:ok, artist} <- apply_country(artist),
+         {:ok, artist} <- apply_images(artist) do
+      {:ok, _} =
+        artist
+        |> Artist.changeset(%{enriched_at: DateTime.utc_now()})
+        |> Repo.update()
+
+      :ok
+    else
+      {:error, :rate_limited} -> {:snooze, 60}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp resolve_mbid(%Artist{mbid: mbid} = artist) when is_binary(mbid), do: {:ok, artist}
+  defp resolve_mbid(artist) do
+    case mbid_from_lastfm(artist) || mbid_from_musicbrainz_search(artist) do
+      {:error, :rate_limited} -> {:error, :rate_limited}
+      nil -> {:ok, artist}
+      mbid when is_binary(mbid) ->
+        {:ok, artist} = artist |> Artist.changeset(%{mbid: mbid}) |> Repo.update()
+        {:ok, artist}
+    end
+  end
+
+  defp mbid_from_lastfm(artist) do
+    case Lastfm.Client.artist_info(artist.name) do
+      {:ok, %{mbid: mbid}} -> mbid
+      _ -> nil
+    end
+  end
+
+  # Only a perfect-score, case-insensitively exact name match is accepted:
+  # linking the wrong artist is worse than linking none.
+  defp mbid_from_musicbrainz_search(artist) do
+    Musicbrainz.Client.search_artist(artist.name)
+    |> musicbrainz_pause()
+    |> case do
+      {:ok, results} ->
+        results
+        |> Enum.find(fn result ->
+          result["score"] == 100 && String.downcase(result["name"] || "") == String.downcase(artist.name)
+        end)
+        |> case do
+          %{"id" => mbid} -> mbid
+          _ -> nil
+        end
+      {:error, :rate_limited} ->
+        {:error, :rate_limited}
+      _ ->
+        nil
+    end
+  end
+
+  defp apply_country(%Artist{mbid: nil} = artist), do: {:ok, artist}
+  defp apply_country(%Artist{country_code: code} = artist) when is_binary(code), do: {:ok, artist}
+  defp apply_country(artist) do
+    Musicbrainz.Client.artist(artist.mbid)
+    |> musicbrainz_pause()
+    |> case do
+      {:ok, data} ->
+        attrs = %{country_code: country_code(data), country_name: get_in(data, ["area", "name"])}
+        {:ok, _} = artist |> Artist.changeset(attrs) |> Repo.update()
+        {:ok, Repo.get(Artist, artist.id)}
+      {:error, :not_found} ->
+        {:ok, artist}
+      error ->
+        error
+    end
+  end
+
+  defp country_code(data) do
+    data["country"] ||
+      case get_in(data, ["area", "iso-3166-1-codes"]) do
+        [code | _] -> code
+        _ -> nil
+      end
+  end
+
+  defp apply_images(artist) do
+    case fanart_images(artist) || deezer_images(artist) do
+      {:error, :rate_limited} -> {:error, :rate_limited}
+      nil -> {:ok, artist}
+      attrs when is_map(attrs) ->
+        {:ok, _} = artist |> Artist.changeset(attrs) |> Repo.update()
+        {:ok, Repo.get(Artist, artist.id)}
+    end
+  end
+
+  defp fanart_images(%Artist{mbid: nil}), do: nil
+  defp fanart_images(artist) do
+    case Fanart.Client.artist_images(artist.mbid) do
+      {:ok, %{thumb_url: thumb, preview_url: preview}} ->
+        %{image_url_small: preview, image_url_medium: preview, image_url_large: thumb, image_source: "fanart"}
+      {:error, :rate_limited} ->
+        {:error, :rate_limited}
+      _ ->
+        nil
+    end
+  end
+
+  defp deezer_images(artist) do
+    case Deezer.Client.search_artist(artist.name) do
+      {:ok, images} ->
+        Map.put(images, :image_source, "deezer")
+      {:error, :rate_limited} ->
+        {:error, :rate_limited}
+      _ ->
+        nil
+    end
+  end
+
+  defp musicbrainz_pause(result) do
+    Process.sleep(Helheim.Musicbrainz.pause_ms())
+    result
+  end
+end

--- a/lib/helheim/music/artist_enrichment_worker.ex
+++ b/lib/helheim/music/artist_enrichment_worker.ex
@@ -4,15 +4,21 @@ defmodule Helheim.Music.ArtistEnrichmentWorker do
   images. Images come from fanart.tv (by MusicBrainz id, community voted)
   with Deezer as the fallback source when fanart has nothing.
 
-  Runs on the concurrency-1 :enrichment queue; see SongEnrichmentWorker
-  for the MusicBrainz pacing rationale.
+  MusicBrainz calls are paced cluster-wide through Helheim.Musicbrainz.paced/1.
+  A force re-run re-resolves the mbid and country as well, so stale
+  Last.fm-seeded ids can be corrected.
   """
 
   use Oban.Worker,
     queue: :enrichment,
     max_attempts: 5,
-    unique: [period: 3600, keys: [:artist_id]]
+    unique: [
+      period: 3600,
+      keys: [:artist_id],
+      states: [:available, :scheduled, :executing, :retryable, :suspended]
+    ]
 
+  require Logger
   alias Helheim.Repo
   alias Helheim.Artist
   alias Helheim.Lastfm
@@ -21,23 +27,30 @@ defmodule Helheim.Music.ArtistEnrichmentWorker do
   alias Helheim.Deezer
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"artist_id" => artist_id} = args}) do
+  def perform(%Oban.Job{args: %{"artist_id" => artist_id} = args} = job) do
     artist = Repo.get(Artist, artist_id)
 
     cond do
       is_nil(artist) -> :ok
       artist.enriched_at && args["force"] != true -> :ok
-      true -> enrich(artist)
+      true -> artist |> enrich(args["force"] == true) |> settle_final_attempt(job, artist)
     end
   end
 
-  defp enrich(artist) do
-    with {:ok, artist} <- resolve_mbid(artist),
-         {:ok, artist} <- apply_country(artist),
-         {:ok, artist} <- apply_images(artist) do
+  defp settle_final_attempt({:error, reason}, %Oban.Job{attempt: attempt, max_attempts: max}, artist) when attempt >= max do
+    Logger.error("Artist enrichment settled with error for artist #{artist.id}: #{inspect(reason)}")
+    {:ok, _} = artist |> Artist.changeset(%{enriched_at: DateTime.utc_now()}) |> Repo.update()
+    :ok
+  end
+  defp settle_final_attempt(result, _job, _artist), do: result
+
+  defp enrich(artist, force) do
+    with {:ok, artist} <- resolve_mbid(artist, force),
+         {:ok, country_attrs} <- country_attrs(artist, force),
+         {:ok, image_attrs} <- image_attrs(artist) do
       {:ok, _} =
         artist
-        |> Artist.changeset(%{enriched_at: DateTime.utc_now()})
+        |> Artist.changeset(Map.merge(country_attrs, Map.put(image_attrs, :enriched_at, DateTime.utc_now())))
         |> Repo.update()
 
       :ok
@@ -47,29 +60,36 @@ defmodule Helheim.Music.ArtistEnrichmentWorker do
     end
   end
 
-  defp resolve_mbid(%Artist{mbid: mbid} = artist) when is_binary(mbid), do: {:ok, artist}
-  defp resolve_mbid(artist) do
+  # A force run re-resolves even a stored mbid so stale ids can heal; the
+  # stored value is kept when re-resolution finds nothing.
+  defp resolve_mbid(%Artist{mbid: mbid} = artist, false) when is_binary(mbid), do: {:ok, artist}
+  defp resolve_mbid(artist, _force) do
     case mbid_from_lastfm(artist) || mbid_from_musicbrainz_search(artist) do
-      {:error, :rate_limited} -> {:error, :rate_limited}
-      nil -> {:ok, artist}
-      mbid when is_binary(mbid) ->
-        {:ok, artist} = artist |> Artist.changeset(%{mbid: mbid}) |> Repo.update()
+      {:error, :rate_limited} ->
+        {:error, :rate_limited}
+      nil ->
         {:ok, artist}
+      mbid when is_binary(mbid) ->
+        if mbid == artist.mbid do
+          {:ok, artist}
+        else
+          artist |> Artist.changeset(%{mbid: mbid}) |> Repo.update()
+        end
     end
   end
 
   defp mbid_from_lastfm(artist) do
     case Lastfm.Client.artist_info(artist.name) do
       {:ok, %{mbid: mbid}} -> mbid
+      {:error, :rate_limited} -> {:error, :rate_limited}
       _ -> nil
     end
   end
 
   # Only a perfect-score, case-insensitively exact name match is accepted:
   # linking the wrong artist is worse than linking none.
-  defp mbid_from_musicbrainz_search(artist) do
-    Musicbrainz.Client.search_artist(artist.name)
-    |> musicbrainz_pause()
+  defp mbid_from_musicbrainz_search(%Artist{} = artist) do
+    Musicbrainz.paced(fn -> Musicbrainz.Client.search_artist(artist.name) end)
     |> case do
       {:ok, results} ->
         results
@@ -87,18 +107,15 @@ defmodule Helheim.Music.ArtistEnrichmentWorker do
     end
   end
 
-  defp apply_country(%Artist{mbid: nil} = artist), do: {:ok, artist}
-  defp apply_country(%Artist{country_code: code} = artist) when is_binary(code), do: {:ok, artist}
-  defp apply_country(artist) do
-    Musicbrainz.Client.artist(artist.mbid)
-    |> musicbrainz_pause()
+  defp country_attrs(%Artist{mbid: nil}, _force), do: {:ok, %{}}
+  defp country_attrs(%Artist{country_code: code}, false) when is_binary(code), do: {:ok, %{}}
+  defp country_attrs(artist, _force) do
+    Musicbrainz.paced(fn -> Musicbrainz.Client.artist(artist.mbid) end)
     |> case do
       {:ok, data} ->
-        attrs = %{country_code: country_code(data), country_name: get_in(data, ["area", "name"])}
-        {:ok, _} = artist |> Artist.changeset(attrs) |> Repo.update()
-        {:ok, Repo.get(Artist, artist.id)}
+        {:ok, %{country_code: country_code(data), country_name: get_in(data, ["area", "name"])}}
       {:error, :not_found} ->
-        {:ok, artist}
+        {:ok, %{}}
       error ->
         error
     end
@@ -112,13 +129,11 @@ defmodule Helheim.Music.ArtistEnrichmentWorker do
       end
   end
 
-  defp apply_images(artist) do
+  defp image_attrs(artist) do
     case fanart_images(artist) || deezer_images(artist) do
       {:error, :rate_limited} -> {:error, :rate_limited}
-      nil -> {:ok, artist}
-      attrs when is_map(attrs) ->
-        {:ok, _} = artist |> Artist.changeset(attrs) |> Repo.update()
-        {:ok, Repo.get(Artist, artist.id)}
+      nil -> {:ok, %{}}
+      attrs when is_map(attrs) -> {:ok, attrs}
     end
   end
 
@@ -143,10 +158,5 @@ defmodule Helheim.Music.ArtistEnrichmentWorker do
       _ ->
         nil
     end
-  end
-
-  defp musicbrainz_pause(result) do
-    Process.sleep(Helheim.Musicbrainz.pause_ms())
-    result
   end
 end

--- a/lib/helheim/music/enrichment.ex
+++ b/lib/helheim/music/enrichment.ex
@@ -1,0 +1,26 @@
+defmodule Helheim.Music.Enrichment do
+  @moduledoc """
+  Backfill entry point: enqueues an enrichment job for every song that has
+  not been enriched yet. Jobs are inserted one by one because Oban's
+  insert_all does not apply unique-job constraints; that keeps repeated
+  backfill runs idempotent, and speed is irrelevant for this one-off admin
+  task. The concurrency-1 enrichment queue then works through the jobs at
+  a rate that respects the external APIs.
+  """
+
+  import Ecto.Query
+  alias Helheim.Repo
+  alias Helheim.Song
+  alias Helheim.Music.SongEnrichmentWorker
+
+  def backfill do
+    Song
+    |> Song.unenriched()
+    |> select([s], s.id)
+    |> Repo.all()
+    |> Enum.map(fn song_id ->
+      {:ok, _} = %{song_id: song_id} |> SongEnrichmentWorker.new() |> Oban.insert()
+    end)
+    |> length()
+  end
+end

--- a/lib/helheim/music/enrichment_sweep_worker.ex
+++ b/lib/helheim/music/enrichment_sweep_worker.ex
@@ -1,0 +1,38 @@
+defmodule Helheim.Music.EnrichmentSweepWorker do
+  @moduledoc """
+  Hourly safety net for the enrichment pipeline: enqueues jobs for songs
+  that are still unenriched. Covers songs whose post-poll enqueue was lost
+  (crash between commit and enqueue) and retries songs whose earlier
+  enrichment attempts were exhausted. Songs younger than an hour are left
+  to the regular poll trigger.
+  """
+
+  use Oban.Worker, queue: :enrichment, max_attempts: 1
+
+  import Ecto.Query
+  alias Helheim.Repo
+  alias Helheim.Song
+  alias Helheim.Music.SongEnrichmentWorker
+
+  @batch_limit 500
+
+  @impl Oban.Worker
+  def perform(_job) do
+    cutoff = DateTime.add(DateTime.utc_now(), -3600, :second)
+
+    Song
+    |> Song.unenriched()
+    |> where([s], s.inserted_at < ^cutoff)
+    |> order_by([s], asc: s.id)
+    |> limit(@batch_limit)
+    |> select([s], s.id)
+    |> Repo.all()
+    |> Enum.each(fn song_id ->
+      %{song_id: song_id}
+      |> SongEnrichmentWorker.new()
+      |> Oban.insert()
+    end)
+
+    :ok
+  end
+end

--- a/lib/helheim/music/song_enrichment_worker.ex
+++ b/lib/helheim/music/song_enrichment_worker.ex
@@ -36,13 +36,13 @@ defmodule Helheim.Music.SongEnrichmentWorker do
     cond do
       is_nil(song) -> :ok
       song.enriched_at && args["force"] != true -> :ok
-      true -> enrich(song)
+      true -> enrich(song, args["force"] == true)
     end
   end
 
-  defp enrich(song) do
+  defp enrich(song, force) do
     with {:ok, song} <- apply_track_info(song),
-         {:ok, song} <- apply_release_year(song),
+         {:ok, song} <- apply_release_year(song, force),
          {:ok, song} <- link_artist(song) do
       {:ok, _} =
         song
@@ -123,8 +123,9 @@ defmodule Helheim.Music.SongEnrichmentWorker do
   # release group via the album mbid (Last.fm album mbids are MusicBrainz
   # release ids), then a recording search by artist + title. Stale Last.fm
   # mbids 404 on MusicBrainz, so every step falls through on :not_found.
-  defp apply_release_year(%Song{release_year: year} = song) when is_integer(year), do: {:ok, song}
-  defp apply_release_year(song) do
+  # A force run re-derives the year so bad data can be corrected.
+  defp apply_release_year(%Song{release_year: year} = song, false) when is_integer(year), do: {:ok, song}
+  defp apply_release_year(song, _force) do
     case release_year_cascade(song) do
       {:ok, nil} ->
         {:ok, song}
@@ -167,14 +168,27 @@ defmodule Helheim.Music.SongEnrichmentWorker do
     end
   end
 
+  # Search results include remasters and compilation recordings whose
+  # first-release-date is years after the original, so take the earliest
+  # year across the hits rather than trusting the top-scored one.
   defp year_from_search(artist, title) do
     Musicbrainz.Client.search_recording(artist, title)
     |> musicbrainz_pause()
     |> case do
-      {:ok, [%{"first-release-date" => date} | _]} -> {:ok, parse_year(date)}
-      {:ok, _} -> {:ok, nil}
-      {:error, :not_found} -> {:ok, nil}
-      error -> error
+      {:ok, recordings} when is_list(recordings) ->
+        year =
+          recordings
+          |> Enum.map(fn recording -> parse_year(recording["first-release-date"]) end)
+          |> Enum.reject(&is_nil/1)
+          |> Enum.min(fn -> nil end)
+
+        {:ok, year}
+      {:ok, _} ->
+        {:ok, nil}
+      {:error, :not_found} ->
+        {:ok, nil}
+      error ->
+        error
     end
   end
 

--- a/lib/helheim/music/song_enrichment_worker.ex
+++ b/lib/helheim/music/song_enrichment_worker.ex
@@ -5,19 +5,25 @@ defmodule Helheim.Music.SongEnrichmentWorker do
   higher resolution cover, the release year (via MusicBrainz) and a link
   to its artist record.
 
-  Runs on the concurrency-1 :enrichment queue and sleeps after each
-  MusicBrainz call, which keeps us within their 1 request/second policy on
-  a single-node deployment. Partial results are fine: enriched_at is
-  stamped even when some sources had nothing, and a re-run can be forced
-  with the "force" arg.
+  MusicBrainz calls are paced cluster-wide through Helheim.Musicbrainz.paced/1.
+  Partial results are fine: enriched_at is stamped even when some sources
+  had nothing, and when the final attempt still errors the song is settled
+  (stamped and logged) so it cannot clog the queue forever - the hourly
+  sweep or a "force" re-run are the recovery paths.
   """
 
   use Oban.Worker,
     queue: :enrichment,
     max_attempts: 5,
-    unique: [period: 3600, keys: [:song_id]]
+    unique: [
+      period: 3600,
+      keys: [:song_id],
+      states: [:available, :scheduled, :executing, :retryable, :suspended]
+    ]
 
   import Ecto.Query
+  require Logger
+  alias Helheim.Cache
   alias Helheim.Repo
   alias Helheim.Artist
   alias Helheim.Song
@@ -30,23 +36,34 @@ defmodule Helheim.Music.SongEnrichmentWorker do
   @max_tags 5
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"song_id" => song_id} = args}) do
+  def perform(%Oban.Job{args: %{"song_id" => song_id} = args} = job) do
     song = Repo.get(Song, song_id)
 
     cond do
       is_nil(song) -> :ok
       song.enriched_at && args["force"] != true -> :ok
-      true -> enrich(song, args["force"] == true)
+      true -> song |> enrich(args["force"] == true) |> settle_final_attempt(job, song)
     end
   end
 
+  # A song that still errors on its last attempt is stamped as enriched so
+  # future polls/sweeps stop re-enqueueing it; force re-runs can revisit.
+  defp settle_final_attempt({:error, reason}, %Oban.Job{attempt: attempt, max_attempts: max}, song) when attempt >= max do
+    Logger.error("Song enrichment settled with error for song #{song.id}: #{inspect(reason)}")
+    {:ok, _} = song |> Song.changeset(%{enriched_at: DateTime.utc_now()}) |> Repo.update()
+    :ok
+  end
+  defp settle_final_attempt(result, _job, _song), do: result
+
   defp enrich(song, force) do
-    with {:ok, song} <- apply_track_info(song),
-         {:ok, song} <- apply_release_year(song, force),
-         {:ok, song} <- link_artist(song) do
+    with {:ok, song, tags} <- apply_track_info(song),
+         :ok <- apply_tags(song, tags),
+         {:ok, release_year} <- resolve_release_year(song, force),
+         {:ok, artist} <- ensure_artist(song) do
       {:ok, _} =
         song
-        |> Song.changeset(%{enriched_at: DateTime.utc_now()})
+        |> Song.changeset(%{release_year: release_year || song.release_year, enriched_at: DateTime.utc_now()})
+        |> Ecto.Changeset.put_change(:artist_id, song.artist_id || artist.id)
         |> Repo.update()
 
       :ok
@@ -56,59 +73,75 @@ defmodule Helheim.Music.SongEnrichmentWorker do
     end
   end
 
-  # Fetches track.getInfo and merges what we do not already know; existing
-  # values are never clobbered.
+  # Fetches track.getInfo and merges what we do not already know in a
+  # single write; existing values are never clobbered. The 500px cover is
+  # derived here too: the Last.fm API caps artwork at 300px, but its CDN
+  # serves a 500px rendition under a rewritten path - the same trick
+  # last.fm's own album pages use.
   defp apply_track_info(song) do
     case Lastfm.Client.track_info(song.artist_name, song.title) do
       {:ok, info} ->
+        cover = song.cover_image_url || info.image_extralarge
+
         attrs = %{
           mbid: song.mbid || info.mbid,
           artist_mbid: song.artist_mbid || info.artist_mbid,
           album_mbid: song.album_mbid || info.album_mbid,
           album_name: song.album_name || info.album_name,
           duration_seconds: song.duration_seconds || info.duration_seconds,
-          cover_image_url: song.cover_image_url || info.image_extralarge,
+          cover_image_url: cover,
+          cover_image_url_large: upgraded_cover_url(cover),
           lastfm_track_url: song.lastfm_track_url || info.url
         }
 
         {:ok, song} = song |> Song.changeset(attrs) |> Repo.update()
-        replace_tags(song, with_artist_tags_fallback(info.tags, song))
-        {:ok, upgrade_cover(song)}
+        {:ok, song, info.tags}
 
       {:error, :not_found} ->
-        replace_tags(song, with_artist_tags_fallback([], song))
-        {:ok, song}
+        {:ok, song, []}
 
       error ->
         error
     end
   end
 
+  defp upgraded_cover_url(nil), do: nil
+  defp upgraded_cover_url(url) do
+    case String.replace(url, "/300x300/", "/500x500/") do
+      ^url -> nil
+      upgraded -> upgraded
+    end
+  end
+
+  defp apply_tags(song, track_tags) do
+    case with_artist_tags_fallback(track_tags, song) do
+      {:error, :rate_limited} -> {:error, :rate_limited}
+      tags -> replace_tags(song, tags)
+    end
+  end
+
   # Track-level tags are sparse on Last.fm outside the mainstream; the
-  # artist's tags are a much better genre signal than nothing.
+  # artist's tags are a much better genre signal than nothing. The artist
+  # lookup is cached so a discography of tagless tracks costs one API call,
+  # and rate limits propagate so the job snoozes instead of losing tags.
   defp with_artist_tags_fallback([], song) do
-    case Lastfm.Client.artist_info(song.artist_name) do
+    Cache.fetch(
+      {:lastfm_artist_tags, String.downcase(song.artist_name)},
+      api_cache_ttl(),
+      fn -> Lastfm.Client.artist_info(song.artist_name) end,
+      cache_if: &match?({:ok, _}, &1)
+    )
+    |> case do
       {:ok, %{tags: tags}} -> tags
+      {:error, :rate_limited} -> {:error, :rate_limited}
       _ -> []
     end
   end
   defp with_artist_tags_fallback(tags, _song), do: tags
 
-  # The Last.fm API caps artwork at 300px, but its CDN serves a 500px
-  # rendition of the same image under a rewritten path - the same trick
-  # last.fm's own album pages use.
-  defp upgrade_cover(%Song{cover_image_url: nil} = song), do: song
-  defp upgrade_cover(%Song{} = song) do
-    large = String.replace(song.cover_image_url, "/300x300/", "/500x500/")
-
-    if large != song.cover_image_url do
-      {:ok, song} = song |> Song.changeset(%{cover_image_url_large: large}) |> Repo.update()
-      song
-    else
-      song
-    end
-  end
-
+  # An empty result never wipes tags a song already has: stale tags beat
+  # data loss from a transient upstream hiccup.
+  defp replace_tags(_song, []), do: :ok
   defp replace_tags(song, tag_names) do
     tags =
       tag_names
@@ -128,27 +161,18 @@ defmodule Helheim.Music.SongEnrichmentWorker do
       |> SongTag.changeset(%{position: position})
       |> Repo.insert!(on_conflict: :nothing, conflict_target: [:song_id, :tag_id])
     end)
+
+    :ok
   end
 
   # Release year lookup cascade: the recording by track mbid, then the
   # release group via the album mbid (Last.fm album mbids are MusicBrainz
   # release ids), then a recording search by artist + title. Stale Last.fm
   # mbids 404 on MusicBrainz, so every step falls through on :not_found.
-  # A force run re-derives the year so bad data can be corrected.
-  defp apply_release_year(%Song{release_year: year} = song, false) when is_integer(year), do: {:ok, song}
-  defp apply_release_year(song, _force) do
-    case release_year_cascade(song) do
-      {:ok, nil} ->
-        {:ok, song}
-      {:ok, year} ->
-        {:ok, _} = song |> Song.changeset(%{release_year: year}) |> Repo.update()
-        {:ok, %{song | release_year: year}}
-      error ->
-        error
-    end
-  end
-
-  defp release_year_cascade(song) do
+  # Returns the year without persisting; the caller folds it into the
+  # final write.
+  defp resolve_release_year(%Song{release_year: year}, false) when is_integer(year), do: {:ok, year}
+  defp resolve_release_year(song, _force) do
     with {:ok, nil} <- year_from_recording(song.mbid),
          {:ok, nil} <- year_from_release(song.album_mbid) do
       year_from_search(song.artist_name, song.title)
@@ -157,8 +181,7 @@ defmodule Helheim.Music.SongEnrichmentWorker do
 
   defp year_from_recording(nil), do: {:ok, nil}
   defp year_from_recording(mbid) do
-    Musicbrainz.Client.recording(mbid)
-    |> musicbrainz_pause()
+    Musicbrainz.paced(fn -> Musicbrainz.Client.recording(mbid) end)
     |> case do
       {:ok, %{"first-release-date" => date}} -> {:ok, parse_year(date)}
       {:ok, _} -> {:ok, nil}
@@ -169,8 +192,7 @@ defmodule Helheim.Music.SongEnrichmentWorker do
 
   defp year_from_release(nil), do: {:ok, nil}
   defp year_from_release(mbid) do
-    Musicbrainz.Client.release(mbid)
-    |> musicbrainz_pause()
+    Musicbrainz.paced(fn -> Musicbrainz.Client.release(mbid) end)
     |> case do
       {:ok, %{"release-group" => %{"first-release-date" => date}}} -> {:ok, parse_year(date)}
       {:ok, _} -> {:ok, nil}
@@ -183,8 +205,7 @@ defmodule Helheim.Music.SongEnrichmentWorker do
   # first-release-date is years after the original, so take the earliest
   # year across the hits rather than trusting the top-scored one.
   defp year_from_search(artist, title) do
-    Musicbrainz.Client.search_recording(artist, title)
-    |> musicbrainz_pause()
+    Musicbrainz.paced(fn -> Musicbrainz.Client.search_recording(artist, title) end)
     |> case do
       {:ok, recordings} when is_list(recordings) ->
         year =
@@ -211,20 +232,11 @@ defmodule Helheim.Music.SongEnrichmentWorker do
   end
   defp parse_year(_), do: nil
 
-  defp musicbrainz_pause(result) do
-    Process.sleep(Helheim.Musicbrainz.pause_ms())
-    result
-  end
-
-  defp link_artist(song) do
+  defp ensure_artist(song) do
     artist = Artist.get_or_create_by_name!(song.artist_name)
 
     if song.artist_mbid && is_nil(artist.mbid) do
       {:ok, _} = artist |> Artist.changeset(%{mbid: song.artist_mbid}) |> Repo.update()
-    end
-
-    if is_nil(song.artist_id) do
-      {:ok, _} = song |> Ecto.Changeset.change(artist_id: artist.id) |> Repo.update()
     end
 
     if is_nil(artist.enriched_at) do
@@ -233,6 +245,10 @@ defmodule Helheim.Music.SongEnrichmentWorker do
       |> Oban.insert()
     end
 
-    {:ok, Repo.get(Song, song.id)}
+    {:ok, artist}
+  end
+
+  defp api_cache_ttl do
+    Application.get_env(:helheim, :api_cache_ttl_ms, :timer.hours(24))
   end
 end

--- a/lib/helheim/music/song_enrichment_worker.ex
+++ b/lib/helheim/music/song_enrichment_worker.ex
@@ -72,16 +72,27 @@ defmodule Helheim.Music.SongEnrichmentWorker do
         }
 
         {:ok, song} = song |> Song.changeset(attrs) |> Repo.update()
-        replace_tags(song, info.tags)
+        replace_tags(song, with_artist_tags_fallback(info.tags, song))
         {:ok, upgrade_cover(song)}
 
       {:error, :not_found} ->
+        replace_tags(song, with_artist_tags_fallback([], song))
         {:ok, song}
 
       error ->
         error
     end
   end
+
+  # Track-level tags are sparse on Last.fm outside the mainstream; the
+  # artist's tags are a much better genre signal than nothing.
+  defp with_artist_tags_fallback([], song) do
+    case Lastfm.Client.artist_info(song.artist_name) do
+      {:ok, %{tags: tags}} -> tags
+      _ -> []
+    end
+  end
+  defp with_artist_tags_fallback(tags, _song), do: tags
 
   # The Last.fm API caps artwork at 300px, but its CDN serves a 500px
   # rendition of the same image under a rewritten path - the same trick

--- a/lib/helheim/music/song_enrichment_worker.ex
+++ b/lib/helheim/music/song_enrichment_worker.ex
@@ -1,0 +1,213 @@
+defmodule Helheim.Music.SongEnrichmentWorker do
+  @moduledoc """
+  Enriches a song with metadata beyond what the scrobble feed provides:
+  MusicBrainz ids, duration, tags (the first doubling as the genre), a
+  higher resolution cover, the release year (via MusicBrainz) and a link
+  to its artist record.
+
+  Runs on the concurrency-1 :enrichment queue and sleeps after each
+  MusicBrainz call, which keeps us within their 1 request/second policy on
+  a single-node deployment. Partial results are fine: enriched_at is
+  stamped even when some sources had nothing, and a re-run can be forced
+  with the "force" arg.
+  """
+
+  use Oban.Worker,
+    queue: :enrichment,
+    max_attempts: 5,
+    unique: [period: 3600, keys: [:song_id]]
+
+  import Ecto.Query
+  alias Helheim.Repo
+  alias Helheim.Artist
+  alias Helheim.Song
+  alias Helheim.SongTag
+  alias Helheim.Tag
+  alias Helheim.Lastfm
+  alias Helheim.Musicbrainz
+  alias Helheim.Music.ArtistEnrichmentWorker
+
+  @max_tags 5
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"song_id" => song_id} = args}) do
+    song = Repo.get(Song, song_id)
+
+    cond do
+      is_nil(song) -> :ok
+      song.enriched_at && args["force"] != true -> :ok
+      true -> enrich(song)
+    end
+  end
+
+  defp enrich(song) do
+    with {:ok, song} <- apply_track_info(song),
+         {:ok, song} <- apply_release_year(song),
+         {:ok, song} <- link_artist(song) do
+      {:ok, _} =
+        song
+        |> Song.changeset(%{enriched_at: DateTime.utc_now()})
+        |> Repo.update()
+
+      :ok
+    else
+      {:error, :rate_limited} -> {:snooze, 60}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # Fetches track.getInfo and merges what we do not already know; existing
+  # values are never clobbered.
+  defp apply_track_info(song) do
+    case Lastfm.Client.track_info(song.artist_name, song.title) do
+      {:ok, info} ->
+        attrs = %{
+          mbid: song.mbid || info.mbid,
+          artist_mbid: song.artist_mbid || info.artist_mbid,
+          album_mbid: song.album_mbid || info.album_mbid,
+          album_name: song.album_name || info.album_name,
+          duration_seconds: song.duration_seconds || info.duration_seconds,
+          cover_image_url: song.cover_image_url || info.image_extralarge,
+          lastfm_track_url: song.lastfm_track_url || info.url
+        }
+
+        {:ok, song} = song |> Song.changeset(attrs) |> Repo.update()
+        replace_tags(song, info.tags)
+        {:ok, upgrade_cover(song)}
+
+      {:error, :not_found} ->
+        {:ok, song}
+
+      error ->
+        error
+    end
+  end
+
+  # The Last.fm API caps artwork at 300px, but its CDN serves a 500px
+  # rendition of the same image under a rewritten path - the same trick
+  # last.fm's own album pages use.
+  defp upgrade_cover(%Song{cover_image_url: nil} = song), do: song
+  defp upgrade_cover(%Song{} = song) do
+    large = String.replace(song.cover_image_url, "/300x300/", "/500x500/")
+
+    if large != song.cover_image_url do
+      {:ok, song} = song |> Song.changeset(%{cover_image_url_large: large}) |> Repo.update()
+      song
+    else
+      song
+    end
+  end
+
+  defp replace_tags(song, tag_names) do
+    tags =
+      tag_names
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(fn name -> name == "" or String.length(name) > 40 end)
+      |> Enum.uniq_by(&String.downcase/1)
+      |> Enum.take(@max_tags)
+
+    Repo.delete_all(from st in SongTag, where: st.song_id == ^song.id)
+
+    tags
+    |> Enum.with_index(1)
+    |> Enum.each(fn {name, position} ->
+      tag = Tag.get_or_create_by_name!(name)
+
+      %SongTag{song_id: song.id, tag_id: tag.id}
+      |> SongTag.changeset(%{position: position})
+      |> Repo.insert!(on_conflict: :nothing, conflict_target: [:song_id, :tag_id])
+    end)
+  end
+
+  # Release year lookup cascade: the recording by track mbid, then the
+  # release group via the album mbid (Last.fm album mbids are MusicBrainz
+  # release ids), then a recording search by artist + title. Stale Last.fm
+  # mbids 404 on MusicBrainz, so every step falls through on :not_found.
+  defp apply_release_year(%Song{release_year: year} = song) when is_integer(year), do: {:ok, song}
+  defp apply_release_year(song) do
+    case release_year_cascade(song) do
+      {:ok, nil} ->
+        {:ok, song}
+      {:ok, year} ->
+        {:ok, _} = song |> Song.changeset(%{release_year: year}) |> Repo.update()
+        {:ok, %{song | release_year: year}}
+      error ->
+        error
+    end
+  end
+
+  defp release_year_cascade(song) do
+    with {:ok, nil} <- year_from_recording(song.mbid),
+         {:ok, nil} <- year_from_release(song.album_mbid) do
+      year_from_search(song.artist_name, song.title)
+    end
+  end
+
+  defp year_from_recording(nil), do: {:ok, nil}
+  defp year_from_recording(mbid) do
+    Musicbrainz.Client.recording(mbid)
+    |> musicbrainz_pause()
+    |> case do
+      {:ok, %{"first-release-date" => date}} -> {:ok, parse_year(date)}
+      {:ok, _} -> {:ok, nil}
+      {:error, :not_found} -> {:ok, nil}
+      error -> error
+    end
+  end
+
+  defp year_from_release(nil), do: {:ok, nil}
+  defp year_from_release(mbid) do
+    Musicbrainz.Client.release(mbid)
+    |> musicbrainz_pause()
+    |> case do
+      {:ok, %{"release-group" => %{"first-release-date" => date}}} -> {:ok, parse_year(date)}
+      {:ok, _} -> {:ok, nil}
+      {:error, :not_found} -> {:ok, nil}
+      error -> error
+    end
+  end
+
+  defp year_from_search(artist, title) do
+    Musicbrainz.Client.search_recording(artist, title)
+    |> musicbrainz_pause()
+    |> case do
+      {:ok, [%{"first-release-date" => date} | _]} -> {:ok, parse_year(date)}
+      {:ok, _} -> {:ok, nil}
+      {:error, :not_found} -> {:ok, nil}
+      error -> error
+    end
+  end
+
+  defp parse_year(date) when is_binary(date) do
+    case Integer.parse(String.slice(date, 0, 4)) do
+      {year, _} when year > 1000 -> year
+      _ -> nil
+    end
+  end
+  defp parse_year(_), do: nil
+
+  defp musicbrainz_pause(result) do
+    Process.sleep(Helheim.Musicbrainz.pause_ms())
+    result
+  end
+
+  defp link_artist(song) do
+    artist = Artist.get_or_create_by_name!(song.artist_name)
+
+    if song.artist_mbid && is_nil(artist.mbid) do
+      {:ok, _} = artist |> Artist.changeset(%{mbid: song.artist_mbid}) |> Repo.update()
+    end
+
+    if is_nil(song.artist_id) do
+      {:ok, _} = song |> Ecto.Changeset.change(artist_id: artist.id) |> Repo.update()
+    end
+
+    if is_nil(artist.enriched_at) do
+      %{artist_id: artist.id}
+      |> ArtistEnrichmentWorker.new()
+      |> Oban.insert()
+    end
+
+    {:ok, Repo.get(Song, song.id)}
+  end
+end

--- a/lib/helheim/musicbrainz/client.ex
+++ b/lib/helheim/musicbrainz/client.ex
@@ -1,0 +1,67 @@
+defmodule Helheim.Musicbrainz.Client do
+  @moduledoc """
+  Thin Req based client for the MusicBrainz API, used to enrich songs and
+  artists with release years and countries.
+
+  MusicBrainz allows one request per second per IP and requires a
+  meaningful User-Agent; callers (the enrichment workers) are responsible
+  for pacing their calls accordingly.
+  """
+
+  @api_url "https://musicbrainz.org/ws/2"
+
+  def artist(mbid) do
+    get("/artist/#{mbid}", %{})
+  end
+
+  def search_artist(name) do
+    case get("/artist", %{query: ~s(artist:"#{escape(name)}"), limit: 5}) do
+      {:ok, %{"artists" => artists}} when is_list(artists) -> {:ok, artists}
+      {:ok, body} -> {:error, {:unexpected_response, body}}
+      error -> error
+    end
+  end
+
+  def recording(mbid) do
+    get("/recording/#{mbid}", %{})
+  end
+
+  # Last.fm album mbids are MusicBrainz *release* ids; the release year
+  # lives on the associated release group.
+  def release(mbid) do
+    get("/release/#{mbid}", %{inc: "release-groups"})
+  end
+
+  def search_recording(artist, title) do
+    query = ~s(recording:"#{escape(title)}" AND artist:"#{escape(artist)}" AND status:official)
+
+    case get("/recording", %{query: query, limit: 5}) do
+      {:ok, %{"recordings" => recordings}} when is_list(recordings) -> {:ok, recordings}
+      {:ok, body} -> {:error, {:unexpected_response, body}}
+      error -> error
+    end
+  end
+
+  defp get(path, params) do
+    params = Map.put(params, :fmt, "json")
+
+    case Req.get(@api_url <> path, params: params, headers: [{"user-agent", config()[:user_agent]}]) do
+      {:ok, %Req.Response{status: 200, body: body}} -> {:ok, body}
+      {:ok, %Req.Response{status: 404}} -> {:error, :not_found}
+      # Invalid/malformed mbids answer 400; treat like a miss so lookup
+      # cascades continue with their fallbacks
+      {:ok, %Req.Response{status: 400}} -> {:error, :not_found}
+      {:ok, %Req.Response{status: 503}} -> {:error, :rate_limited}
+      {:ok, %Req.Response{status: status, body: body}} -> {:error, {:http_error, status, body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp escape(value) do
+    value
+    |> String.replace("\\", "\\\\")
+    |> String.replace("\"", "\\\"")
+  end
+
+  defp config, do: Application.get_env(:helheim, :musicbrainz)
+end

--- a/lib/helheim/musicbrainz/musicbrainz.ex
+++ b/lib/helheim/musicbrainz/musicbrainz.ex
@@ -1,10 +1,32 @@
 defmodule Helheim.Musicbrainz do
   @moduledoc """
-  Shared MusicBrainz settings. The pause is inserted after every API call
-  by the enrichment workers, which run on a concurrency-1 queue - together
-  that keeps us within MusicBrainz's 1 request/second policy on a single
-  node deployment.
+  Cluster-wide pacing for MusicBrainz API calls. MusicBrainz allows one
+  request per second per IP; the app runs on multiple machines behind one
+  egress, so per-process sleeping is not enough. `paced/1` serializes the
+  call plus a cooldown across ALL nodes via a Postgres advisory lock: only
+  one MusicBrainz request can be in flight (or cooling down) at any time,
+  no matter how many machines run the enrichment queue.
   """
+
+  alias Helheim.Repo
+
+  # Arbitrary but stable application-wide lock id for MusicBrainz pacing.
+  @advisory_lock_key 727_274_269
+
+  def paced(fun) do
+    {:ok, result} =
+      Repo.transaction(
+        fn ->
+          Ecto.Adapters.SQL.query!(Repo, "SELECT pg_advisory_xact_lock($1)", [@advisory_lock_key])
+          result = fun.()
+          Process.sleep(pause_ms())
+          result
+        end,
+        timeout: :infinity
+      )
+
+    result
+  end
 
   def pause_ms do
     Application.get_env(:helheim, :musicbrainz)[:pause_ms] || 1100

--- a/lib/helheim/musicbrainz/musicbrainz.ex
+++ b/lib/helheim/musicbrainz/musicbrainz.ex
@@ -1,0 +1,12 @@
+defmodule Helheim.Musicbrainz do
+  @moduledoc """
+  Shared MusicBrainz settings. The pause is inserted after every API call
+  by the enrichment workers, which run on a concurrency-1 queue - together
+  that keeps us within MusicBrainz's 1 request/second policy on a single
+  node deployment.
+  """
+
+  def pause_ms do
+    Application.get_env(:helheim, :musicbrainz)[:pause_ms] || 1100
+  end
+end

--- a/lib/helheim/named_lookup.ex
+++ b/lib/helheim/named_lookup.ex
@@ -1,0 +1,31 @@
+defmodule Helheim.NamedLookup do
+  @moduledoc """
+  Shared case-insensitive find-or-create for schemas whose identity is a
+  `lower(name)` unique index (artists, tags).
+
+  The insert uses ON CONFLICT DO UPDATE with RETURNING rather than DO
+  NOTHING, so the existing row always comes back with its id - both under
+  concurrent inserts and when Elixir's String.downcase and Postgres'
+  lower() disagree about the casefolding of a name (in which case the
+  Elixir-side lookup misses but the index still conflicts).
+  """
+
+  import Ecto.Query
+  alias Helheim.Repo
+
+  def get_or_create!(schema, name) do
+    get(schema, name) ||
+      schema
+      |> struct()
+      |> schema.changeset(%{name: name})
+      |> Repo.insert!(
+        on_conflict: {:replace, [:updated_at]},
+        conflict_target: {:unsafe_fragment, "(lower(name))"},
+        returning: true
+      )
+  end
+
+  def get(schema, name) do
+    Repo.one(from r in schema, where: fragment("lower(?)", r.name) == ^String.downcase(name))
+  end
+end

--- a/lib/helheim_web/controllers/song_controller.ex
+++ b/lib/helheim_web/controllers/song_controller.ex
@@ -37,7 +37,10 @@ defmodule HelheimWeb.SongController do
   end
 
   def show(conn, %{"id" => id} = params) do
-    song = Repo.get!(Song, id)
+    song =
+      Song
+      |> Repo.get!(id)
+      |> Repo.preload(song_tags: {Helheim.SongTag.ordered(Helheim.SongTag), [:tag]})
     current_user = current_resource(conn)
     recent_listens =
       SongListen

--- a/lib/helheim_web/controllers/song_listen_controller.ex
+++ b/lib/helheim_web/controllers/song_listen_controller.ex
@@ -24,13 +24,31 @@ defmodule HelheimWeb.SongListenController do
       if page == 1 do
         {
           Song |> Song.top_for_user(user) |> limit(10) |> Repo.all,
-          Song |> Song.top_artists_for_user(user) |> limit(10) |> Repo.all
+          Song |> Song.top_artists_for_user(user) |> limit(10) |> Repo.all |> with_artist_records()
         }
       else
         {nil, nil}
       end
 
     render(conn, "index.html", user: user, listens: listens, top_songs: top_songs, top_artists: top_artists)
+  end
+
+  # Joins the aggregated {artist_name, count} rows with their enriched
+  # artist records (images, nationality) in a single lookup. Songs whose
+  # artist has not been enriched yet still appear, just without extras.
+  defp with_artist_records([]), do: []
+  defp with_artist_records(top_artists) do
+    names = Enum.map(top_artists, fn {artist_name, _count} -> artist_name end)
+
+    artists_by_name =
+      Helheim.Artist
+      |> Helheim.Artist.by_names(names)
+      |> Repo.all()
+      |> Map.new(fn artist -> {String.downcase(artist.name), artist} end)
+
+    Enum.map(top_artists, fn {artist_name, count} ->
+      {artist_name, count, artists_by_name[String.downcase(artist_name)]}
+    end)
   end
 
   defp find_user(conn, _) do

--- a/lib/helheim_web/templates/song/_cover.html.eex
+++ b/lib/helheim_web/templates/song/_cover.html.eex
@@ -1,7 +1,7 @@
-<a href="<%= song_path(@conn, :show, @song) %>" class="d-flex mr-1">
-  <%= if @song.cover_image_url_small do %>
-    <img src="<%= @song.cover_image_url_small %>" class="rounded" alt="" width="64" height="64">
+<a href="<%= @href %>" class="d-flex mr-1"<%= if assigns[:external] do %> target="_blank" rel="noopener"<% end %>>
+  <%= if assigns[:image_url] do %>
+    <img src="<%= @image_url %>" class="rounded" alt="" width="64" height="64">
   <% else %>
-    <div class="song-cover-placeholder rounded"><i class="fa fa-music"></i></div>
+    <div class="song-cover-placeholder rounded"><i class="fa <%= assigns[:icon] || "fa-music" %>"></i></div>
   <% end %>
 </a>

--- a/lib/helheim_web/templates/song/_listen.html.eex
+++ b/lib/helheim_web/templates/song/_listen.html.eex
@@ -1,5 +1,5 @@
 <div class="media mb-1">
-  <%= render "_cover.html", conn: @conn, song: @listen.song %>
+  <%= render "_cover.html", href: song_path(@conn, :show, @listen.song), image_url: @listen.song.cover_image_url_small %>
   <div class="media-body">
     <%= link @listen.song.title, to: song_path(@conn, :show, @listen.song) %>
     <br>

--- a/lib/helheim_web/templates/song/_song.html.eex
+++ b/lib/helheim_web/templates/song/_song.html.eex
@@ -1,5 +1,5 @@
 <div class="media mb-1">
-  <%= render "_cover.html", conn: @conn, song: @song %>
+  <%= render "_cover.html", href: song_path(@conn, :show, @song), image_url: @song.cover_image_url_small %>
   <div class="media-body">
     <%= link @song.title, to: song_path(@conn, :show, @song) %>
     <br>

--- a/lib/helheim_web/templates/song/show.html.eex
+++ b/lib/helheim_web/templates/song/show.html.eex
@@ -4,8 +4,8 @@
 <div class="row">
   <div class="col-md-4">
     <div class="card">
-      <%= if @song.cover_image_url do %>
-        <img class="card-img-top img-fluid" src="<%= @song.cover_image_url %>" alt="">
+      <%= if detail_cover_url(@song) do %>
+        <img class="card-img-top img-fluid" src="<%= detail_cover_url(@song) %>" alt="">
       <% end %>
       <div class="card-block">
         <table class="table table-sm">
@@ -19,11 +19,30 @@
               <td><%= @song.album_name %></td>
             </tr>
           <% end %>
+          <%= if @song.release_year do %>
+            <tr>
+              <th><%= gettext "Year" %></th>
+              <td><%= @song.release_year %></td>
+            </tr>
+          <% end %>
+          <%= if genre_tag = List.first(@song.song_tags) do %>
+            <tr>
+              <th><%= gettext "Genre" %></th>
+              <td><%= genre_tag.tag.name %></td>
+            </tr>
+          <% end %>
           <tr>
             <th><%= gettext "Listens" %></th>
             <td><%= @song.listens_count %></td>
           </tr>
         </table>
+        <%= if length(@song.song_tags) > 0 do %>
+          <p>
+            <%= for song_tag <- @song.song_tags do %>
+              <span class="badge badge-default"><i class="fa fa-fw fa-tag"></i> <%= song_tag.tag.name %></span>
+            <% end %>
+          </p>
+        <% end %>
         <p class="mb-0">
           <%= lastfm_link @song.lastfm_track_url, gettext("Song on Last.fm") %><br>
           <%= lastfm_link lastfm_artist_url(@song.artist_name), gettext("Artist on Last.fm") %>

--- a/lib/helheim_web/templates/song_listen/index.html.eex
+++ b/lib/helheim_web/templates/song_listen/index.html.eex
@@ -20,14 +20,23 @@
         <%= if length(@top_artists) == 0 do %>
           <p class="text-muted mb-0"><%= gettext "No listens have been tracked yet..." %></p>
         <% end %>
-        <ol class="pl-2 mb-0">
-          <%= for {artist_name, count} <- @top_artists do %>
-            <li>
+        <%= for {artist_name, count, artist} <- @top_artists do %>
+          <div class="media mb-1">
+            <%= if artist && artist.image_url_medium do %>
+              <img src="<%= artist.image_url_medium %>" class="d-flex mr-1 rounded" alt="" width="64" height="64">
+            <% else %>
+              <div class="song-cover-placeholder rounded d-flex mr-1"><i class="fa fa-user"></i></div>
+            <% end %>
+            <div class="media-body">
               <%= link artist_name, to: HelheimWeb.SongView.lastfm_artist_url(artist_name), target: "_blank", rel: "noopener" %>
+              <%= if artist && artist.country_code do %>
+                <span title="<%= artist.country_name %>"><%= HelheimWeb.SongView.country_flag(artist.country_code) %></span>
+              <% end %>
+              <br>
               <%= HelheimWeb.SongView.listen_count_badge(count) %>
-            </li>
-          <% end %>
-        </ol>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/lib/helheim_web/templates/song_listen/index.html.eex
+++ b/lib/helheim_web/templates/song_listen/index.html.eex
@@ -22,11 +22,11 @@
         <% end %>
         <%= for {artist_name, count, artist} <- @top_artists do %>
           <div class="media mb-1">
-            <%= if artist && artist.image_url_medium do %>
-              <img src="<%= artist.image_url_medium %>" class="d-flex mr-1 rounded" alt="" width="64" height="64">
-            <% else %>
-              <div class="song-cover-placeholder rounded d-flex mr-1"><i class="fa fa-user"></i></div>
-            <% end %>
+            <%= render HelheimWeb.SongView, "_cover.html",
+                  href: HelheimWeb.SongView.lastfm_artist_url(artist_name),
+                  image_url: artist && artist.image_url_medium,
+                  icon: "fa-user",
+                  external: true %>
             <div class="media-body">
               <%= link artist_name, to: HelheimWeb.SongView.lastfm_artist_url(artist_name), target: "_blank", rel: "noopener" %>
               <%= if artist && artist.country_code do %>

--- a/lib/helheim_web/views/song_view.ex
+++ b/lib/helheim_web/views/song_view.ex
@@ -1,6 +1,23 @@
 defmodule HelheimWeb.SongView do
   use HelheimWeb, :view
 
+  def detail_cover_url(song) do
+    song.cover_image_url_large || song.cover_image_url
+  end
+
+  @doc """
+  Renders an ISO 3166-1 alpha-2 country code as its flag emoji via the
+  regional indicator codepoints - no image assets needed.
+  """
+  def country_flag(<<_, _>> = country_code) do
+    country_code
+    |> String.upcase()
+    |> String.to_charlist()
+    |> Enum.map(&(&1 + 127_397))
+    |> List.to_string()
+  end
+  def country_flag(_), do: nil
+
   def listen_count_badge(count) do
     content_tag :span, class: "badge badge-default" do
       [content_tag(:i, "", class: "fa fa-fw fa-headphones"), {:safe, [" #{count}"]}]

--- a/lib/helheim_web/views/song_view.ex
+++ b/lib/helheim_web/views/song_view.ex
@@ -7,14 +7,22 @@ defmodule HelheimWeb.SongView do
 
   @doc """
   Renders an ISO 3166-1 alpha-2 country code as its flag emoji via the
-  regional indicator codepoints - no image assets needed.
+  regional indicator codepoints - no image assets needed. MusicBrainz's
+  user-assigned region codes (XW worldwide, XE Europe, ...) have no flag
+  and render as letter boxes, so they are skipped - except XK (Kosovo),
+  which platforms do render.
   """
-  def country_flag(<<_, _>> = country_code) do
-    country_code
-    |> String.upcase()
-    |> String.to_charlist()
-    |> Enum.map(&(&1 + 127_397))
-    |> List.to_string()
+  def country_flag(country_code) when is_binary(country_code) do
+    case String.upcase(country_code) do
+      <<a, b>> = upcased when a in ?A..?Z and b in ?A..?Z ->
+        if a == ?X and upcased != "XK" do
+          nil
+        else
+          upcased |> String.to_charlist() |> Enum.map(&(&1 + 127_397)) |> List.to_string()
+        end
+      _ ->
+        nil
+    end
   end
   def country_flag(_), do: nil
 

--- a/lib/mix/tasks/helheim.enrich_backfill.ex
+++ b/lib/mix/tasks/helheim.enrich_backfill.ex
@@ -1,0 +1,13 @@
+defmodule Mix.Tasks.Helheim.EnrichBackfill do
+  @moduledoc "Enqueues metadata enrichment jobs for all unenriched songs."
+  @shortdoc "Backfills song metadata enrichment"
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+    count = Helheim.Music.Enrichment.backfill()
+    Mix.shell().info("Enqueued enrichment for #{count} songs")
+  end
+end

--- a/priv/gettext/da/LC_MESSAGES/default.po
+++ b/priv/gettext/da/LC_MESSAGES/default.po
@@ -2698,7 +2698,7 @@ msgstr "%{who} skrev en kommentar til sangen: %{what}"
 msgid "Album"
 msgstr "Album"
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:38
+#: lib/helheim_web/templates/song_listen/index.html.eex:47
 #, elixir-autogen, elixir-format
 msgid "All listens"
 msgstr "Alle afspilninger"
@@ -2728,7 +2728,7 @@ msgstr "Slet lyttehistorik"
 msgid "Latest listens"
 msgstr "Seneste afspilninger"
 
-#: lib/helheim_web/templates/song/show.html.eex:23
+#: lib/helheim_web/templates/song/show.html.eex:35
 #, elixir-autogen, elixir-format
 msgid "Listens"
 msgstr "Afspilninger"
@@ -2741,17 +2741,17 @@ msgstr "Musik fra %{username}"
 #: lib/helheim_web/templates/song/recent.html.eex:6
 #: lib/helheim_web/templates/song_listen/index.html.eex:9
 #: lib/helheim_web/templates/song_listen/index.html.eex:21
-#: lib/helheim_web/templates/song_listen/index.html.eex:40
+#: lib/helheim_web/templates/song_listen/index.html.eex:49
 #, elixir-autogen, elixir-format
 msgid "No listens have been tracked yet..."
 msgstr "Der er ikke registreret nogen afspilninger endnu..."
 
-#: lib/helheim_web/templates/song/show.html.eex:53
+#: lib/helheim_web/templates/song/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "No one has listened to this song yet..."
 msgstr "Ingen har lyttet til denne sang endnu..."
 
-#: lib/helheim_web/templates/song/show.html.eex:51
+#: lib/helheim_web/templates/song/show.html.eex:70
 #, elixir-autogen, elixir-format
 msgid "Recent listeners"
 msgstr "Seneste lyttere"
@@ -2787,27 +2787,27 @@ msgstr "Du kan også slette hele din lyttehistorik fra siden. Dette kan ikke for
 msgid "Your listening history has been deleted."
 msgstr "Din lyttehistorik er blevet slettet."
 
-#: lib/helheim_web/templates/song/show.html.eex:38
+#: lib/helheim_web/templates/song/show.html.eex:57
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Your listens of this song will be permanently removed!"
 msgstr "Er du sikker? Dine afspilninger af denne sang bliver fjernet permanent!"
 
-#: lib/helheim_web/templates/song/show.html.eex:40
+#: lib/helheim_web/templates/song/show.html.eex:59
 #, elixir-autogen, elixir-format
 msgid "Remove my name from this song"
 msgstr "Fjern mit navn fra denne sang"
 
-#: lib/helheim_web/controllers/song_controller.ex:73
+#: lib/helheim_web/controllers/song_controller.ex:76
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr "Dine afspilninger er blevet fjernet fra denne sang."
 
-#: lib/helheim_web/templates/song/show.html.eex:32
+#: lib/helheim_web/templates/song/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Album on Last.fm"
 msgstr "Album på Last.fm"
 
-#: lib/helheim_web/templates/song/show.html.eex:29
+#: lib/helheim_web/templates/song/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "Artist on Last.fm"
 msgstr "Kunstner på Last.fm"
@@ -2853,7 +2853,7 @@ msgstr "Forbind Last.fm igen"
 msgid "Set up scrobbling on Last.fm"
 msgstr "Opsæt scrobbling på Last.fm"
 
-#: lib/helheim_web/templates/song/show.html.eex:28
+#: lib/helheim_web/templates/song/show.html.eex:47
 #, elixir-autogen, elixir-format
 msgid "Song on Last.fm"
 msgstr "Sang på Last.fm"
@@ -2902,3 +2902,13 @@ msgstr "Top sange, seneste 24 timer"
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 7 days"
 msgstr "Top sange, seneste 7 dage"
+
+#: lib/helheim_web/templates/song/show.html.eex:30
+#, elixir-autogen, elixir-format
+msgid "Genre"
+msgstr "Genre"
+
+#: lib/helheim_web/templates/song/show.html.eex:24
+#, elixir-autogen, elixir-format
+msgid "Year"
+msgstr "Årstal"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2687,7 +2687,7 @@ msgstr ""
 msgid "Album"
 msgstr ""
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:38
+#: lib/helheim_web/templates/song_listen/index.html.eex:47
 #, elixir-autogen, elixir-format
 msgid "All listens"
 msgstr ""
@@ -2717,7 +2717,7 @@ msgstr ""
 msgid "Latest listens"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:23
+#: lib/helheim_web/templates/song/show.html.eex:35
 #, elixir-autogen, elixir-format
 msgid "Listens"
 msgstr ""
@@ -2730,17 +2730,17 @@ msgstr ""
 #: lib/helheim_web/templates/song/recent.html.eex:6
 #: lib/helheim_web/templates/song_listen/index.html.eex:9
 #: lib/helheim_web/templates/song_listen/index.html.eex:21
-#: lib/helheim_web/templates/song_listen/index.html.eex:40
+#: lib/helheim_web/templates/song_listen/index.html.eex:49
 #, elixir-autogen, elixir-format
 msgid "No listens have been tracked yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:53
+#: lib/helheim_web/templates/song/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "No one has listened to this song yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:51
+#: lib/helheim_web/templates/song/show.html.eex:70
 #, elixir-autogen, elixir-format
 msgid "Recent listeners"
 msgstr ""
@@ -2776,27 +2776,27 @@ msgstr ""
 msgid "Your listening history has been deleted."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:38
+#: lib/helheim_web/templates/song/show.html.eex:57
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Your listens of this song will be permanently removed!"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:40
+#: lib/helheim_web/templates/song/show.html.eex:59
 #, elixir-autogen, elixir-format
 msgid "Remove my name from this song"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:73
+#: lib/helheim_web/controllers/song_controller.ex:76
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:32
+#: lib/helheim_web/templates/song/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Album on Last.fm"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:29
+#: lib/helheim_web/templates/song/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "Artist on Last.fm"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Set up scrobbling on Last.fm"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:28
+#: lib/helheim_web/templates/song/show.html.eex:47
 #, elixir-autogen, elixir-format
 msgid "Song on Last.fm"
 msgstr ""
@@ -2890,4 +2890,14 @@ msgstr ""
 #: lib/helheim_web/templates/page/front_page.html.eex:111
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 7 days"
+msgstr ""
+
+#: lib/helheim_web/templates/song/show.html.eex:30
+#, elixir-autogen, elixir-format
+msgid "Genre"
+msgstr ""
+
+#: lib/helheim_web/templates/song/show.html.eex:24
+#, elixir-autogen, elixir-format
+msgid "Year"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2687,7 +2687,7 @@ msgstr ""
 msgid "Album"
 msgstr ""
 
-#: lib/helheim_web/templates/song_listen/index.html.eex:38
+#: lib/helheim_web/templates/song_listen/index.html.eex:47
 #, elixir-autogen, elixir-format
 msgid "All listens"
 msgstr ""
@@ -2717,7 +2717,7 @@ msgstr ""
 msgid "Latest listens"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:23
+#: lib/helheim_web/templates/song/show.html.eex:35
 #, elixir-autogen, elixir-format
 msgid "Listens"
 msgstr ""
@@ -2730,17 +2730,17 @@ msgstr ""
 #: lib/helheim_web/templates/song/recent.html.eex:6
 #: lib/helheim_web/templates/song_listen/index.html.eex:9
 #: lib/helheim_web/templates/song_listen/index.html.eex:21
-#: lib/helheim_web/templates/song_listen/index.html.eex:40
+#: lib/helheim_web/templates/song_listen/index.html.eex:49
 #, elixir-autogen, elixir-format
 msgid "No listens have been tracked yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:53
+#: lib/helheim_web/templates/song/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "No one has listened to this song yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:51
+#: lib/helheim_web/templates/song/show.html.eex:70
 #, elixir-autogen, elixir-format
 msgid "Recent listeners"
 msgstr ""
@@ -2776,27 +2776,27 @@ msgstr ""
 msgid "Your listening history has been deleted."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:38
+#: lib/helheim_web/templates/song/show.html.eex:57
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure? Your listens of this song will be permanently removed!"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:40
+#: lib/helheim_web/templates/song/show.html.eex:59
 #, elixir-autogen, elixir-format
 msgid "Remove my name from this song"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:73
+#: lib/helheim_web/controllers/song_controller.ex:76
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:32
+#: lib/helheim_web/templates/song/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Album on Last.fm"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:29
+#: lib/helheim_web/templates/song/show.html.eex:48
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Artist on Last.fm"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Set up scrobbling on Last.fm"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:28
+#: lib/helheim_web/templates/song/show.html.eex:47
 #, elixir-autogen, elixir-format
 msgid "Song on Last.fm"
 msgstr ""
@@ -2890,4 +2890,14 @@ msgstr ""
 #: lib/helheim_web/templates/page/front_page.html.eex:111
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Top songs, past 7 days"
+msgstr ""
+
+#: lib/helheim_web/templates/song/show.html.eex:30
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Genre"
+msgstr ""
+
+#: lib/helheim_web/templates/song/show.html.eex:24
+#, elixir-autogen, elixir-format
+msgid "Year"
 msgstr ""

--- a/priv/repo/migrations/20260713000001_create_artists.exs
+++ b/priv/repo/migrations/20260713000001_create_artists.exs
@@ -1,0 +1,21 @@
+defmodule Helheim.Repo.Migrations.CreateArtists do
+  use Ecto.Migration
+
+  def change do
+    create table(:artists) do
+      add :name, :string, null: false
+      add :mbid, :string
+      add :country_code, :string
+      add :country_name, :string
+      add :image_url_small, :string
+      add :image_url_medium, :string
+      add :image_url_large, :string
+      add :image_source, :string
+      add :enriched_at, :utc_datetime_usec
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:artists, ["lower(name)"], name: :artists_name_index)
+  end
+end

--- a/priv/repo/migrations/20260713000002_add_enrichment_to_songs.exs
+++ b/priv/repo/migrations/20260713000002_add_enrichment_to_songs.exs
@@ -1,0 +1,19 @@
+defmodule Helheim.Repo.Migrations.AddEnrichmentToSongs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:songs) do
+      add :mbid, :string
+      add :artist_mbid, :string
+      add :album_mbid, :string
+      add :release_year, :integer
+      add :duration_seconds, :integer
+      add :cover_image_url_large, :string
+      add :artist_id, references(:artists, on_delete: :nilify_all)
+      add :enriched_at, :utc_datetime_usec
+    end
+
+    create index(:songs, [:artist_id])
+    create index(:songs, [:id], where: "enriched_at IS NULL", name: :songs_unenriched_index)
+  end
+end

--- a/priv/repo/migrations/20260713000003_create_tags.exs
+++ b/priv/repo/migrations/20260713000003_create_tags.exs
@@ -1,0 +1,24 @@
+defmodule Helheim.Repo.Migrations.CreateTags do
+  use Ecto.Migration
+
+  def change do
+    create table(:tags) do
+      add :name, :string, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:tags, ["lower(name)"], name: :tags_name_index)
+
+    create table(:songs_tags) do
+      add :song_id, references(:songs, on_delete: :delete_all), null: false
+      add :tag_id, references(:tags, on_delete: :delete_all), null: false
+      add :position, :integer, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:songs_tags, [:song_id, :tag_id])
+    create index(:songs_tags, [:tag_id])
+  end
+end

--- a/test/helheim/lastfm/payload_test.exs
+++ b/test/helheim/lastfm/payload_test.exs
@@ -1,0 +1,44 @@
+defmodule Helheim.Lastfm.PayloadTest do
+  use ExUnit.Case, async: true
+  alias Helheim.Lastfm.Payload
+
+  describe "image_url/2" do
+    test "picks the url for the requested size" do
+      images = [
+        %{"size" => "medium", "#text" => "https://img/64.jpg"},
+        %{"size" => "extralarge", "#text" => "https://img/300.jpg"}
+      ]
+      assert Payload.image_url(images, "extralarge") == "https://img/300.jpg"
+    end
+
+    test "treats blanks and the placeholder star as no image" do
+      placeholder = "https://img/2a96cbd8b46e442fc41c2b86b821562f.png"
+      assert Payload.image_url([%{"size" => "medium", "#text" => ""}], "medium") == nil
+      assert Payload.image_url([%{"size" => "medium", "#text" => placeholder}], "medium") == nil
+    end
+
+    test "tolerates non-list and malformed payloads" do
+      assert Payload.image_url("not a list", "medium") == nil
+      assert Payload.image_url(nil, "medium") == nil
+      assert Payload.image_url(["junk"], "medium") == nil
+    end
+  end
+
+  describe "tag_names/1" do
+    test "extracts names from a tag list" do
+      assert Payload.tag_names(%{"tag" => [%{"name" => "metal"}, %{"name" => "80s"}]}) == ["metal", "80s"]
+    end
+
+    test "handles a bare single tag object" do
+      assert Payload.tag_names(%{"tag" => %{"name" => "metal"}}) == ["metal"]
+    end
+
+    test "tolerates the API's inconsistent empty serializations" do
+      assert Payload.tag_names(%{"tag" => []}) == []
+      assert Payload.tag_names("") == []
+      assert Payload.tag_names([]) == []
+      assert Payload.tag_names(nil) == []
+      assert Payload.tag_names(%{"tag" => ["junk", %{"name" => "metal"}]}) == ["metal"]
+    end
+  end
+end

--- a/test/helheim/lastfm/sync_service_test.exs
+++ b/test/helheim/lastfm/sync_service_test.exs
@@ -187,6 +187,27 @@ defmodule Helheim.Lastfm.SyncServiceTest do
       assert Repo.get(Song, song.id).mbid == "track-mbid"
     end
 
+    test "a re-scrobble never clobbers enrichment data", %{account: account} do
+      artist = insert(:artist)
+      song = insert(:song,
+        artist_name: "Metallica",
+        title: "Orion",
+        enriched_at: DateTime.utc_now(),
+        release_year: 1986,
+        duration_seconds: 500,
+        cover_image_url_large: "https://lastfm.freetls.fastly.net/i/u/500x500/abc.jpg",
+        artist: artist)
+
+      {:ok, _} = SyncService.sync_listens!(account, [item("Orion", @uts_10_00)])
+
+      updated = Repo.get(Song, song.id)
+      assert updated.enriched_at == song.enriched_at
+      assert updated.release_year == 1986
+      assert updated.duration_seconds == 500
+      assert updated.cover_image_url_large == song.cover_image_url_large
+      assert updated.artist_id == artist.id
+    end
+
     test "enqueues enrichment for songs that have not been enriched yet", %{account: account} do
       {:ok, _} = SyncService.sync_listens!(account, [item("Orion", @uts_10_00)])
 

--- a/test/helheim/lastfm/sync_service_test.exs
+++ b/test/helheim/lastfm/sync_service_test.exs
@@ -1,10 +1,12 @@
 defmodule Helheim.Lastfm.SyncServiceTest do
   use Helheim.DataCase
+  use Oban.Testing, repo: Helheim.Repo
   alias Helheim.Repo
   alias Helheim.Song
   alias Helheim.SongListen
   alias Helheim.LastfmAccount
   alias Helheim.Lastfm.SyncService
+  alias Helheim.Music.SongEnrichmentWorker
 
   @uts_10_00 1_783_591_200
   @uts_11_00 1_783_594_800
@@ -165,6 +167,39 @@ defmodule Helheim.Lastfm.SyncServiceTest do
       account = Repo.get(LastfmAccount, account.id)
       assert account.played_after_cursor == @uts_11_00
       assert account.last_polled_at
+    end
+
+    test "captures musicbrainz ids from the scrobble without clobbering existing ones", %{account: account} do
+      overrides = %{
+        "mbid" => "track-mbid",
+        "artist" => %{"#text" => "Metallica", "mbid" => "artist-mbid"},
+        "album" => %{"#text" => "Ride the Lightning", "mbid" => "album-mbid"}
+      }
+      {:ok, _} = SyncService.sync_listens!(account, [item("Orion", @uts_10_00, overrides)])
+
+      song = Repo.get_by!(Song, title: "Orion")
+      assert song.mbid == "track-mbid"
+      assert song.artist_mbid == "artist-mbid"
+      assert song.album_mbid == "album-mbid"
+
+      no_mbids = item("Orion", @uts_11_00, %{"mbid" => ""})
+      {:ok, _} = SyncService.sync_listens!(account, [no_mbids])
+      assert Repo.get(Song, song.id).mbid == "track-mbid"
+    end
+
+    test "enqueues enrichment for songs that have not been enriched yet", %{account: account} do
+      {:ok, _} = SyncService.sync_listens!(account, [item("Orion", @uts_10_00)])
+
+      song = Repo.get_by!(Song, title: "Orion")
+      assert_enqueued worker: SongEnrichmentWorker, args: %{song_id: song.id}
+    end
+
+    test "does not enqueue enrichment for songs that are already enriched", %{account: account} do
+      song = insert(:song, artist_name: "Metallica", title: "Orion", enriched_at: DateTime.utc_now())
+
+      {:ok, _} = SyncService.sync_listens!(account, [item("Orion", @uts_10_00)])
+
+      refute_enqueued worker: SongEnrichmentWorker, args: %{song_id: song.id}
     end
 
     test "keeps the existing cursor when there are no items", %{account: account} do

--- a/test/helheim/music/artist_enrichment_worker_test.exs
+++ b/test/helheim/music/artist_enrichment_worker_test.exs
@@ -110,6 +110,43 @@ defmodule Helheim.Music.ArtistEnrichmentWorkerTest do
       assert :ok = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id})
       assert not called Musicbrainz.Client.artist(:_)
     end
+
+    test "snoozes when last.fm rate limits during a force mbid re-resolution" do
+      artist = insert_unenriched_artist(enriched_at: DateTime.utc_now())
+
+      with_mock Lastfm.Client, [:passthrough], [artist_info: fn _name -> {:error, :rate_limited} end] do
+        assert {:snooze, 60} = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id, force: true})
+      end
+    end
+
+    test "a force run re-resolves a stale stored mbid" do
+      artist = insert_unenriched_artist(mbid: "stale-mbid", enriched_at: DateTime.utc_now())
+
+      with_mocks([
+        {Lastfm.Client, [:passthrough], [artist_info: fn "Iotunn" -> {:ok, %{mbid: "fresh-mbid", url: nil, tags: []}} end]},
+        {Musicbrainz.Client, [:passthrough], [artist: fn "fresh-mbid" -> @mb_artist end]},
+        {Fanart.Client, [:passthrough], [artist_images: fn "fresh-mbid" -> @fanart_images end]}
+      ]) do
+        assert :ok = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id, force: true})
+      end
+
+      artist = Repo.get(Artist, artist.id)
+      assert artist.mbid == "fresh-mbid"
+      assert artist.country_code == "DK"
+    end
+
+    test "settles an artist whose final attempt still errors" do
+      artist = insert_unenriched_artist(mbid: nil)
+
+      with_mocks([
+        {Lastfm.Client, [:passthrough], [artist_info: fn _name -> {:error, :not_found} end]},
+        {Musicbrainz.Client, [:passthrough], [search_artist: fn _name -> {:error, {:http_error, 500, "boom"}} end]}
+      ]) do
+        assert :ok = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id}, attempt: 5)
+      end
+
+      assert Repo.get(Artist, artist.id).enriched_at
+    end
   end
 
   describe "perform/1 without a stored mbid" do

--- a/test/helheim/music/artist_enrichment_worker_test.exs
+++ b/test/helheim/music/artist_enrichment_worker_test.exs
@@ -1,0 +1,167 @@
+defmodule Helheim.Music.ArtistEnrichmentWorkerTest do
+  use Helheim.DataCase
+  use Oban.Testing, repo: Helheim.Repo
+  import Mock
+  alias Helheim.Repo
+  alias Helheim.Artist
+  alias Helheim.Lastfm
+  alias Helheim.Musicbrainz
+  alias Helheim.Fanart
+  alias Helheim.Deezer
+  alias Helheim.Music.ArtistEnrichmentWorker
+
+  @mb_artist {:ok, %{"country" => "DK", "area" => %{"name" => "Denmark", "iso-3166-1-codes" => ["DK"]}}}
+  @fanart_images {:ok, %{
+    thumb_url: "https://assets.fanart.tv/fanart/music/mbid/artistthumb/pic.jpg",
+    preview_url: "https://assets.fanart.tv/preview/music/mbid/artistthumb/pic.jpg"
+  }}
+  @deezer_images {:ok, %{
+    image_url_small: "https://e-cdns-images.dzcdn.net/56x56.jpg",
+    image_url_medium: "https://e-cdns-images.dzcdn.net/250x250.jpg",
+    image_url_large: "https://e-cdns-images.dzcdn.net/1000x1000.jpg"
+  }}
+
+  defp insert_unenriched_artist(attrs \\ []) do
+    insert(:artist, Keyword.merge([
+      name: "Iotunn", mbid: "artist-mbid", country_code: nil, country_name: nil,
+      image_url_small: nil, image_url_medium: nil, image_url_large: nil,
+      image_source: nil, enriched_at: nil
+    ], attrs))
+  end
+
+  describe "perform/1 with a known mbid" do
+    setup_with_mocks([
+      {Musicbrainz.Client, [:passthrough], [artist: fn "artist-mbid" -> @mb_artist end]},
+      {Fanart.Client, [:passthrough], [artist_images: fn "artist-mbid" -> @fanart_images end]}
+    ]) do
+      :ok
+    end
+
+    test "stores the country and fanart images and marks the artist enriched" do
+      artist = insert_unenriched_artist()
+
+      assert :ok = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id})
+
+      artist = Repo.get(Artist, artist.id)
+      assert artist.country_code == "DK"
+      assert artist.country_name == "Denmark"
+      assert artist.image_url_small =~ "/preview/"
+      assert artist.image_url_large =~ "/fanart/"
+      assert artist.image_source == "fanart"
+      assert artist.enriched_at
+    end
+
+    test "falls back to deezer when fanart has no images" do
+      artist = insert_unenriched_artist()
+
+      with_mocks([
+        {Fanart.Client, [:passthrough], [artist_images: fn _mbid -> {:error, :not_found} end]},
+        {Deezer.Client, [:passthrough], [search_artist: fn "Iotunn" -> @deezer_images end]}
+      ]) do
+        assert :ok = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id})
+      end
+
+      artist = Repo.get(Artist, artist.id)
+      assert artist.image_url_large =~ "1000x1000"
+      assert artist.image_source == "deezer"
+    end
+
+    test "falls back to deezer when fanart is not configured" do
+      artist = insert_unenriched_artist()
+
+      with_mocks([
+        {Fanart.Client, [:passthrough], [artist_images: fn _mbid -> {:error, :not_configured} end]},
+        {Deezer.Client, [:passthrough], [search_artist: fn _name -> @deezer_images end]}
+      ]) do
+        assert :ok = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id})
+      end
+
+      assert Repo.get(Artist, artist.id).image_source == "deezer"
+    end
+
+    test "marks the artist enriched even when no image source has anything" do
+      artist = insert_unenriched_artist()
+
+      with_mocks([
+        {Fanart.Client, [:passthrough], [artist_images: fn _mbid -> {:error, :not_found} end]},
+        {Deezer.Client, [:passthrough], [search_artist: fn _name -> {:error, :not_found} end]}
+      ]) do
+        assert :ok = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id})
+      end
+
+      artist = Repo.get(Artist, artist.id)
+      assert artist.image_url_small == nil
+      assert artist.enriched_at
+    end
+
+    test "snoozes when an image source rate limits" do
+      artist = insert_unenriched_artist()
+
+      with_mock Fanart.Client, [:passthrough], [artist_images: fn _mbid -> {:error, :rate_limited} end] do
+        assert {:snooze, 60} = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id})
+      end
+
+      refute Repo.get(Artist, artist.id).enriched_at
+    end
+
+    test "skips artists that are already enriched" do
+      artist = insert_unenriched_artist(enriched_at: DateTime.utc_now())
+
+      assert :ok = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id})
+      assert not called Musicbrainz.Client.artist(:_)
+    end
+  end
+
+  describe "perform/1 without a stored mbid" do
+    setup do
+      [artist: insert_unenriched_artist(mbid: nil)]
+    end
+
+    test "resolves the mbid via last.fm first", %{artist: artist} do
+      with_mocks([
+        {Lastfm.Client, [:passthrough], [artist_info: fn "Iotunn" -> {:ok, %{mbid: "artist-mbid", url: nil}} end]},
+        {Musicbrainz.Client, [:passthrough], [artist: fn "artist-mbid" -> @mb_artist end]},
+        {Fanart.Client, [:passthrough], [artist_images: fn "artist-mbid" -> @fanart_images end]}
+      ]) do
+        assert :ok = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id})
+      end
+
+      artist = Repo.get(Artist, artist.id)
+      assert artist.mbid == "artist-mbid"
+      assert artist.country_code == "DK"
+    end
+
+    test "falls back to a perfect-score exact musicbrainz search match", %{artist: artist} do
+      with_mocks([
+        {Lastfm.Client, [:passthrough], [artist_info: fn _name -> {:ok, %{mbid: nil, url: nil}} end]},
+        {Musicbrainz.Client, [:passthrough], [
+          search_artist: fn "Iotunn" -> {:ok, [%{"id" => "artist-mbid", "score" => 100, "name" => "IOTUNN"}]} end,
+          artist: fn "artist-mbid" -> @mb_artist end
+        ]},
+        {Fanart.Client, [:passthrough], [artist_images: fn _mbid -> {:error, :not_found} end]},
+        {Deezer.Client, [:passthrough], [search_artist: fn _name -> {:error, :not_found} end]}
+      ]) do
+        assert :ok = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id})
+      end
+
+      assert Repo.get(Artist, artist.id).mbid == "artist-mbid"
+    end
+
+    test "rejects search matches that are not exact", %{artist: artist} do
+      with_mocks([
+        {Lastfm.Client, [:passthrough], [artist_info: fn _name -> {:error, :not_found} end]},
+        {Musicbrainz.Client, [:passthrough], [
+          search_artist: fn _name -> {:ok, [%{"id" => "wrong-mbid", "score" => 90, "name" => "Iotunn Tribute Band"}]} end
+        ]},
+        {Deezer.Client, [:passthrough], [search_artist: fn _name -> {:error, :not_found} end]}
+      ]) do
+        assert :ok = perform_job(ArtistEnrichmentWorker, %{artist_id: artist.id})
+      end
+
+      artist = Repo.get(Artist, artist.id)
+      assert artist.mbid == nil
+      assert artist.country_code == nil
+      assert artist.enriched_at
+    end
+  end
+end

--- a/test/helheim/music/enrichment_sweep_worker_test.exs
+++ b/test/helheim/music/enrichment_sweep_worker_test.exs
@@ -1,0 +1,20 @@
+defmodule Helheim.Music.EnrichmentSweepWorkerTest do
+  use Helheim.DataCase
+  use Oban.Testing, repo: Helheim.Repo
+  alias Helheim.Repo
+  alias Helheim.Music.EnrichmentSweepWorker
+  alias Helheim.Music.SongEnrichmentWorker
+
+  test "enqueues enrichment for unenriched songs older than an hour" do
+    old_unenriched = insert(:song, enriched_at: nil)
+    Repo.update_all(Helheim.Song, set: [inserted_at: Timex.shift(Timex.now, hours: -2)])
+    fresh_unenriched = insert(:song, enriched_at: nil)
+    enriched = insert(:song, enriched_at: DateTime.utc_now())
+
+    assert :ok = perform_job(EnrichmentSweepWorker, %{})
+
+    assert_enqueued worker: SongEnrichmentWorker, args: %{song_id: old_unenriched.id}
+    refute_enqueued worker: SongEnrichmentWorker, args: %{song_id: fresh_unenriched.id}
+    refute_enqueued worker: SongEnrichmentWorker, args: %{song_id: enriched.id}
+  end
+end

--- a/test/helheim/music/enrichment_test.exs
+++ b/test/helheim/music/enrichment_test.exs
@@ -1,0 +1,28 @@
+defmodule Helheim.Music.EnrichmentTest do
+  use Helheim.DataCase
+  use Oban.Testing, repo: Helheim.Repo
+  alias Helheim.Music.Enrichment
+  alias Helheim.Music.SongEnrichmentWorker
+
+  describe "backfill/0" do
+    test "enqueues enrichment for every unenriched song" do
+      song_1 = insert(:song, enriched_at: nil)
+      song_2 = insert(:song, enriched_at: nil)
+      enriched = insert(:song, enriched_at: DateTime.utc_now())
+
+      assert Enrichment.backfill() == 2
+
+      assert_enqueued worker: SongEnrichmentWorker, args: %{song_id: song_1.id}
+      assert_enqueued worker: SongEnrichmentWorker, args: %{song_id: song_2.id}
+      refute_enqueued worker: SongEnrichmentWorker, args: %{song_id: enriched.id}
+    end
+
+    test "is idempotent thanks to job uniqueness" do
+      insert(:song, enriched_at: nil)
+
+      assert Enrichment.backfill() == 1
+      assert Enrichment.backfill() == 1
+      assert length(all_enqueued(worker: SongEnrichmentWorker)) == 1
+    end
+  end
+end

--- a/test/helheim/music/song_enrichment_worker_test.exs
+++ b/test/helheim/music/song_enrichment_worker_test.exs
@@ -111,13 +111,33 @@ defmodule Helheim.Music.SongEnrichmentWorkerTest do
     test "still enriches when last.fm does not know the track" do
       song = insert_unenriched_song(cover_image_url: nil)
 
-      with_mock Lastfm.Client, [:passthrough], [track_info: fn _a, _t -> {:error, :not_found} end] do
+      with_mock Lastfm.Client, [:passthrough], [
+        track_info: fn _a, _t -> {:error, :not_found} end,
+        artist_info: fn _name -> {:error, :not_found} end
+      ] do
         assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
       end
 
       song = Repo.get(Song, song.id)
       assert song.enriched_at
       assert song.release_year == 1986
+    end
+
+    test "falls back to the artist's tags when the track has none" do
+      song = insert_unenriched_song()
+
+      with_mock Lastfm.Client, [:passthrough], [
+        track_info: fn _a, _t ->
+          {:ok, info} = @track_info
+          {:ok, %{info | tags: []}}
+        end,
+        artist_info: fn "Metallica" -> {:ok, %{mbid: nil, url: nil, tags: ["heavy metal", "thrash metal"]}} end
+      ] do
+        assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+      end
+
+      song = Repo.get(Song, song.id) |> Repo.preload(:tags)
+      assert Enum.map(song.tags, & &1.name) |> Enum.sort() == ["heavy metal", "thrash metal"]
     end
   end
 

--- a/test/helheim/music/song_enrichment_worker_test.exs
+++ b/test/helheim/music/song_enrichment_worker_test.exs
@@ -141,13 +141,19 @@ defmodule Helheim.Music.SongEnrichmentWorkerTest do
       assert Repo.get(Song, song.id).release_year == 1999
     end
 
-    test "falls back to the recording search when both mbid lookups miss" do
+    test "falls back to the recording search when both mbid lookups miss, taking the earliest year" do
       song = insert_unenriched_song()
 
       with_mock Musicbrainz.Client, [:passthrough], [
         recording: fn _mbid -> {:error, :not_found} end,
         release: fn _mbid -> {:error, :not_found} end,
-        search_recording: fn "Metallica", "Battery" -> {:ok, [%{"first-release-date" => "1986-03-03"}]} end
+        search_recording: fn "Metallica", "Battery" ->
+          {:ok, [
+            %{"first-release-date" => "2001-10-01"},
+            %{"first-release-date" => "1986-03-03"},
+            %{"title" => "no date on this one"}
+          ]}
+        end
       ] do
         assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
       end

--- a/test/helheim/music/song_enrichment_worker_test.exs
+++ b/test/helheim/music/song_enrichment_worker_test.exs
@@ -123,6 +123,56 @@ defmodule Helheim.Music.SongEnrichmentWorkerTest do
       assert song.release_year == 1986
     end
 
+    test "keeps existing tags when the fresh lookup has none" do
+      song = insert_unenriched_song()
+      tag = insert(:tag, name: "prog metal")
+      Repo.insert!(%SongTag{song_id: song.id, tag_id: tag.id, position: 1})
+
+      with_mock Lastfm.Client, [:passthrough], [
+        track_info: fn _a, _t ->
+          {:ok, info} = @track_info
+          {:ok, %{info | tags: []}}
+        end,
+        artist_info: fn _name -> {:error, :not_found} end
+      ] do
+        assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id, force: true})
+      end
+
+      song = Repo.get(Song, song.id) |> Repo.preload(:tags)
+      assert Enum.map(song.tags, & &1.name) == ["prog metal"]
+    end
+
+    test "snoozes instead of losing tags when the artist tag fallback is rate limited" do
+      song = insert_unenriched_song()
+      tag = insert(:tag, name: "prog metal")
+      Repo.insert!(%SongTag{song_id: song.id, tag_id: tag.id, position: 1})
+
+      with_mock Lastfm.Client, [:passthrough], [
+        track_info: fn _a, _t ->
+          {:ok, info} = @track_info
+          {:ok, %{info | tags: []}}
+        end,
+        artist_info: fn _name -> {:error, :rate_limited} end
+      ] do
+        assert {:snooze, 60} = perform_job(SongEnrichmentWorker, %{song_id: song.id, force: true})
+      end
+
+      assert Repo.aggregate(from(st in SongTag, where: st.song_id == ^song.id), :count) == 1
+    end
+
+    test "settles a song whose final attempt still errors so it stops clogging the queue" do
+      song = insert_unenriched_song()
+
+      with_mock Lastfm.Client, [:passthrough], [
+        track_info: fn _a, _t -> {:error, {:api_error, 16, "temporary"}} end
+      ] do
+        assert {:error, _} = perform_job(SongEnrichmentWorker, %{song_id: song.id}, attempt: 1)
+        assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id}, attempt: 5)
+      end
+
+      assert Repo.get(Song, song.id).enriched_at
+    end
+
     test "falls back to the artist's tags when the track has none" do
       song = insert_unenriched_song()
 

--- a/test/helheim/music/song_enrichment_worker_test.exs
+++ b/test/helheim/music/song_enrichment_worker_test.exs
@@ -1,0 +1,184 @@
+defmodule Helheim.Music.SongEnrichmentWorkerTest do
+  use Helheim.DataCase
+  use Oban.Testing, repo: Helheim.Repo
+  import Mock
+  alias Helheim.Repo
+  alias Helheim.Artist
+  alias Helheim.Song
+  alias Helheim.SongTag
+  alias Helheim.Tag
+  alias Helheim.Lastfm
+  alias Helheim.Musicbrainz
+  alias Helheim.Music.ArtistEnrichmentWorker
+  alias Helheim.Music.SongEnrichmentWorker
+
+  @track_info {:ok, %{
+    mbid: "track-mbid",
+    artist_mbid: "artist-mbid",
+    album_mbid: "album-mbid",
+    album_name: "Master of Puppets",
+    duration_seconds: 315,
+    image_extralarge: "https://lastfm.freetls.fastly.net/i/u/300x300/abc.jpg",
+    tags: ["thrash metal", "metal", "80s"],
+    url: "https://www.last.fm/music/Metallica/_/Battery"
+  }}
+
+  defp insert_unenriched_song(attrs \\ []) do
+    insert(:song, Keyword.merge([
+      title: "Battery",
+      artist_name: "Metallica",
+      cover_image_url: "https://lastfm.freetls.fastly.net/i/u/300x300/abc.jpg",
+      mbid: nil, artist_mbid: nil, album_mbid: nil, release_year: nil,
+      duration_seconds: nil, cover_image_url_large: nil, enriched_at: nil
+    ], attrs))
+  end
+
+  describe "perform/1" do
+    setup_with_mocks([
+      {Lastfm.Client, [:passthrough], [track_info: fn _artist, _title -> @track_info end]},
+      {Musicbrainz.Client, [:passthrough], [
+        recording: fn _mbid -> {:ok, %{"first-release-date" => "1986-03-03"}} end,
+        release: fn _mbid -> {:ok, %{"release-group" => %{"first-release-date" => "1986"}}} end,
+        search_recording: fn _artist, _title -> {:ok, [%{"first-release-date" => "1986-03-03"}]} end
+      ]}
+    ]) do
+      :ok
+    end
+
+    test "enriches the song with mbids, duration, release year, tags, cover and artist" do
+      song = insert_unenriched_song()
+
+      assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+
+      song = Repo.get(Song, song.id) |> Repo.preload(:tags)
+      assert song.mbid == "track-mbid"
+      assert song.artist_mbid == "artist-mbid"
+      assert song.album_mbid == "album-mbid"
+      assert song.duration_seconds == 315
+      assert song.release_year == 1986
+      assert song.cover_image_url_large == "https://lastfm.freetls.fastly.net/i/u/500x500/abc.jpg"
+      assert song.enriched_at
+      assert Enum.map(song.tags, & &1.name) |> Enum.sort() == ["80s", "metal", "thrash metal"]
+
+      artist = Repo.get_by!(Artist, name: "Metallica")
+      assert song.artist_id == artist.id
+      assert artist.mbid == "artist-mbid"
+      assert_enqueued worker: ArtistEnrichmentWorker, args: %{artist_id: artist.id}
+    end
+
+    test "does not clobber values the song already has" do
+      song = insert_unenriched_song(mbid: "existing-mbid", album_name: "Existing Album", duration_seconds: 100)
+
+      assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+
+      song = Repo.get(Song, song.id)
+      assert song.mbid == "existing-mbid"
+      assert song.album_name == "Existing Album"
+      assert song.duration_seconds == 100
+    end
+
+    test "skips songs that are already enriched" do
+      song = insert_unenriched_song(enriched_at: DateTime.utc_now())
+
+      assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+      assert not called Lastfm.Client.track_info(:_, :_)
+    end
+
+    test "re-enriches when forced" do
+      song = insert_unenriched_song(enriched_at: DateTime.utc_now())
+
+      assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id, force: true})
+      assert called Lastfm.Client.track_info("Metallica", "Battery")
+    end
+
+    test "skips songs that no longer exist" do
+      assert :ok = perform_job(SongEnrichmentWorker, %{song_id: 1_234_567})
+    end
+
+    test "reuses existing tags case-insensitively and replaces assignments idempotently" do
+      existing_tag = insert(:tag, name: "Thrash Metal")
+      song = insert_unenriched_song()
+
+      assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+      assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id, force: true})
+
+      song_tags = Repo.all(from st in SongTag, where: st.song_id == ^song.id)
+      assert length(song_tags) == 3
+      assert Repo.aggregate(from(t in Tag, where: fragment("lower(?)", t.name) == "thrash metal"), :count) == 1
+      assert Enum.any?(song_tags, & &1.tag_id == existing_tag.id)
+    end
+
+    test "still enriches when last.fm does not know the track" do
+      song = insert_unenriched_song(cover_image_url: nil)
+
+      with_mock Lastfm.Client, [:passthrough], [track_info: fn _a, _t -> {:error, :not_found} end] do
+        assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+      end
+
+      song = Repo.get(Song, song.id)
+      assert song.enriched_at
+      assert song.release_year == 1986
+    end
+  end
+
+  describe "release year cascade" do
+    setup_with_mocks([
+      {Lastfm.Client, [:passthrough], [track_info: fn _artist, _title -> @track_info end]}
+    ]) do
+      :ok
+    end
+
+    test "falls back from a stale recording mbid to the release lookup" do
+      song = insert_unenriched_song()
+
+      with_mock Musicbrainz.Client, [:passthrough], [
+        recording: fn _mbid -> {:error, :not_found} end,
+        release: fn "album-mbid" -> {:ok, %{"release-group" => %{"first-release-date" => "1999-11-23"}}} end
+      ] do
+        assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+      end
+
+      assert Repo.get(Song, song.id).release_year == 1999
+    end
+
+    test "falls back to the recording search when both mbid lookups miss" do
+      song = insert_unenriched_song()
+
+      with_mock Musicbrainz.Client, [:passthrough], [
+        recording: fn _mbid -> {:error, :not_found} end,
+        release: fn _mbid -> {:error, :not_found} end,
+        search_recording: fn "Metallica", "Battery" -> {:ok, [%{"first-release-date" => "1986-03-03"}]} end
+      ] do
+        assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+      end
+
+      assert Repo.get(Song, song.id).release_year == 1986
+    end
+
+    test "leaves the release year empty when nothing matches but still marks the song enriched" do
+      song = insert_unenriched_song()
+
+      with_mock Musicbrainz.Client, [:passthrough], [
+        recording: fn _mbid -> {:error, :not_found} end,
+        release: fn _mbid -> {:error, :not_found} end,
+        search_recording: fn _a, _t -> {:ok, []} end
+      ] do
+        assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+      end
+
+      song = Repo.get(Song, song.id)
+      assert song.release_year == nil
+      assert song.enriched_at
+    end
+
+    test "snoozes when musicbrainz rate limits" do
+      song = insert_unenriched_song()
+
+      with_mock Musicbrainz.Client, [:passthrough], [recording: fn _mbid -> {:error, :rate_limited} end] do
+        assert {:snooze, 60} = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+      end
+
+      refute Repo.get(Song, song.id).enriched_at
+    end
+  end
+end

--- a/test/helheim_web/controllers/song_controller_test.exs
+++ b/test/helheim_web/controllers/song_controller_test.exs
@@ -153,6 +153,21 @@ defmodule HelheimWeb.SongControllerTest do
       refute html_response(conn, 200) =~ "ignored-individual"
     end
 
+    test "it shows the enriched metadata when present", %{conn: conn} do
+      song = insert(:song,
+        release_year: 1986,
+        cover_image_url: "https://lastfm.freetls.fastly.net/i/u/300x300/abc.jpg",
+        cover_image_url_large: "https://lastfm.freetls.fastly.net/i/u/500x500/abc.jpg")
+      tag = insert(:tag, name: "thrash metal")
+      Repo.insert!(%Helheim.SongTag{song_id: song.id, tag_id: tag.id, position: 1})
+
+      conn = get conn, "/songs/#{song.id}"
+      response = html_response(conn, 200)
+      assert response =~ "1986"
+      assert response =~ "thrash metal"
+      assert response =~ "500x500"
+    end
+
     test "it shows the comments of the song", %{conn: conn} do
       comment = insert(:song_comment, body: "What a fantastic track")
 

--- a/test/helheim_web/controllers/song_listen_controller_test.exs
+++ b/test/helheim_web/controllers/song_listen_controller_test.exs
@@ -15,6 +15,20 @@ defmodule HelheimWeb.SongListenControllerTest do
       assert response =~ "Metallica"
     end
 
+    test "it shows artist images and nationality for enriched artists", %{conn: conn} do
+      profile = insert(:user)
+      insert(:artist, name: "Iotunn", country_code: "DK", country_name: "Denmark",
+        image_url_medium: "https://assets.fanart.tv/preview/music/abc/artistthumb/iotunn.jpg")
+      song = insert(:song, artist_name: "Iotunn")
+      insert(:song_listen, user: profile, song: song)
+
+      conn = get conn, "/profiles/#{profile.id}/music"
+      response = html_response(conn, 200)
+      assert response =~ "iotunn.jpg"
+      assert response =~ "Denmark"
+      assert response =~ "🇩🇰"
+    end
+
     test "it does not show listens from other users", %{conn: conn} do
       profile = insert(:user)
       song = insert(:song, title: "Creeping Death")

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -232,6 +232,26 @@ defmodule Helheim.Factory do
     }
   end
 
+  def artist_factory do
+    %Helheim.Artist{
+      name: sequence(:artist_name, &"Metallica #{&1}"),
+      mbid: sequence(:artist_mbid, &"65f4f0c5-ef9e-490c-aee3-909e7ae6b#{&1}"),
+      country_code: "US",
+      country_name: "United States",
+      image_url_small: "https://assets.fanart.tv/preview/music/abc/artistthumb/small.jpg",
+      image_url_medium: "https://assets.fanart.tv/preview/music/abc/artistthumb/medium.jpg",
+      image_url_large: "https://assets.fanart.tv/fanart/music/abc/artistthumb/large.jpg",
+      image_source: "fanart",
+      enriched_at: DateTime.utc_now()
+    }
+  end
+
+  def tag_factory do
+    %Helheim.Tag{
+      name: sequence(:tag_name, &"thrash metal #{&1}")
+    }
+  end
+
   def song_listen_factory do
     %Helheim.SongListen{
       user: build(:user),


### PR DESCRIPTION
## What

Songs and artists now carry rich metadata beyond what the scrobble feed provides, filled in asynchronously by a new enrichment pipeline:

**Songs** gain MusicBrainz ids (track/artist/album), release year, duration, a 500px cover and up to 5 ranked Last.fm tags (the top tag doubles as the genre, all normalized into `tags` + `songs_tags`). The detail page shows the bigger cover, year, genre and tag badges.

**Artists** (new denormalized table, identity = case-insensitive name like songs) gain a MusicBrainz id, nationality (country code + name) and images in several resolutions. The top-artists list on the profile music page becomes media entries with the artist image, a flag emoji for the nationality and the listen count.

**Pipeline**: a concurrency-1 `enrichment` Oban queue with two workers. `SongEnrichmentWorker` pulls `track.getInfo` (never clobbering known values), resolves the release year through a MusicBrainz cascade (recording by mbid → release group via album mbid → recording search taking the **earliest** year, since search hits include remasters — caught live with a 1979 track scoring a 2001 remaster), replaces tags, and links/creates the artist. `ArtistEnrichmentWorker` resolves the artist mbid (stored → Last.fm → perfect-score exact MusicBrainz match), fetches the country from MusicBrainz, and images from fanart.tv with Deezer as fallback. The sync now captures mbids from the scrobble feed for free and enqueues enrichment for new songs; `mix helheim.enrich_backfill` covers the existing catalog.

## API notes (verified live)

- The Last.fm API caps artwork at 300px ("mega" is the same file). The 500px cover comes from Last.fm's own CDN rendition path (`/i/u/300x300/` → `/i/u/500x500/`), with render-time fallback to 300px.
- Last.fm artist images have been a placeholder star since 2019, hence fanart.tv/Deezer.
- Last.fm mbids can be stale (404 on MusicBrainz) — every MB lookup falls through to the next source.
- MusicBrainz is paced at <1 req/s: concurrency-1 queue + a pause after every call (single-node guarantee; a global limiter would be needed if the app ever clusters).

## Deploy notes

- Three additive migrations.
- Optional secret: `FANART_API_KEY` (register at fanart.tv/get-an-api-key). Without it, artist images gracefully fall back to Deezer (keyless).
- After deploy, run the backfill from a remote console: `Helheim.Music.Enrichment.backfill()` — jobs then drain through the enrichment queue at API-friendly pace.

## Testing

1543 tests green. New coverage: both workers (happy path, stale-mbid cascade, fanart→Deezer fallback, no-image and rate-limit paths, force re-runs, tag idempotency), sync mbid capture + enqueue trigger, backfill idempotency (per-job inserts because Oban's `insert_all` bypasses unique constraints), enriched UI rendering. Also verified end-to-end in dev against the live APIs: real songs got correct mbids, years (1979/2013 after the earliest-year fix), tags, 500px covers, and artists got Deezer images + MusicBrainz nationality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)