### PR TITLE
Add Oban Lifeline plugin to rescue orphaned executing jobs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -45,6 +45,11 @@ config :helheim, Oban,
   queues: [lastfm: 5, enrichment: 1],
   plugins: [
     {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
+    # Rescue jobs orphaned in the executing state when their node dies -
+    # Fly auto-stops idle machines mid-job (observed in production with an
+    # enrichment job stuck executing for 48 minutes). 15 minutes is far
+    # above any legitimate job runtime here.
+    {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(15)},
     {Oban.Plugins.Cron,
      crontab: [
        {"*/5 * * * *", Helheim.Lastfm.SchedulerWorker},


### PR DESCRIPTION
## What

Adds `Oban.Plugins.Lifeline` (rescue after 15 minutes) to the Oban configuration.

## Why

Fly auto-stops idle machines (`auto_stop_machines = "stop"`, `min_machines_running = 1`), and a machine can be stopped **while an Oban job is executing on it**. This happened in production immediately after the enrichment deploy: machine `1850006a227578` was auto-stopped at 12:48, twelve minutes after it started executing a `SongEnrichmentWorker` job — the job then sat orphaned in the `executing` state for 48 minutes (blocking the backfill's last song) until it was manually transitioned back to `available`.

Lifeline exists exactly for this: it periodically rescues jobs stuck in `executing` beyond `rescue_after`, returning them to `available` so a live node picks them up. 15 minutes is far above any legitimate job runtime in this app (the longest jobs are enrichment workers making a handful of paced API calls).

## Testing

Full suite green (1558 tests). The plugin is inert under `testing: :manual`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)