### PR TITLE
Add 30 second song previews via Deezer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ npm-debug.log
 
 # OS caches
 .DS_store
+
+# Claude Code local tooling config
+/.claude/

--- a/assets/css/_custom.scss
+++ b/assets/css/_custom.scss
@@ -311,6 +311,40 @@ code {
 }
 
 
+.song-cover-frame {
+  position: relative;
+
+  .song-preview-overlay {
+    position: absolute;
+    bottom: 3px;
+    left: 3px;
+  }
+}
+
+.song-preview-overlay {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  cursor: pointer;
+
+  &:hover,
+  &:focus {
+    background-color: rgba(0, 0, 0, 0.85);
+    color: #fff;
+  }
+
+  i {
+    font-size: 0.75rem;
+  }
+}
+
 .song-cover-placeholder {
   width: 64px;
   height: 64px;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -45,6 +45,7 @@ import { CalendarEventForm } from "./calendar_event_form";
 import { PreferencesForm } from "./preferences_form";
 import { BlockForm } from "./block_form";
 import { IgnoreForm } from "./ignore_form";
+import { SongPreview } from "./song_preview";
 
 import css from "../css/app.css.scss"
 
@@ -71,6 +72,7 @@ export var App = {
     PreferencesForm.run();
     BlockForm.run();
     IgnoreForm.run();
+    SongPreview.run();
   }
 }
 

--- a/assets/js/song_preview.js
+++ b/assets/js/song_preview.js
@@ -1,0 +1,56 @@
+// Plays 30 second song previews via buttons rendered by
+// HelheimWeb.SongView.preview_button/3. Only one preview plays at a time:
+// starting one stops whatever else was playing, and clicking the button
+// of the playing preview stops it again.
+export var SongPreview = {
+  audio: null,
+  button: null,
+
+  run: function(){
+    const buttons = document.querySelectorAll('.song-preview-button');
+
+    for (let i = 0; i < buttons.length; i++) {
+      buttons[i].addEventListener('click', (event) => {
+        event.preventDefault();
+        this.toggle(event.currentTarget);
+      });
+    }
+  },
+
+  toggle: function(button){
+    const wasPlaying = (this.button === button);
+    this.stop();
+    if (!wasPlaying) { this.play(button); }
+  },
+
+  play: function(button){
+    // Only try to play if the browser supports it
+    try {
+      const audio = new Audio(button.dataset.previewUrl);
+      this.audio = audio;
+      this.button = button;
+      this.setIcon('fa-circle-o-notch fa-spin');
+      audio.addEventListener('playing', () => { if (this.audio === audio) { this.setIcon('fa-stop'); } });
+      audio.addEventListener('ended', () => { if (this.audio === audio) { this.stop(); } });
+      audio.addEventListener('error', () => { if (this.audio === audio) { this.stop(); } });
+      audio.play().catch(() => { if (this.audio === audio) { this.stop(); } });
+    } catch(e) {
+      this.stop();
+    }
+  },
+
+  stop: function(){
+    if (this.audio) {
+      this.audio.pause();
+      this.audio = null;
+    }
+    this.setIcon('fa-play');
+    this.button = null;
+  },
+
+  setIcon: function(icon){
+    if (!this.button) { return; }
+    const iconElm = this.button.querySelector('i');
+    if (iconElm) { iconElm.className = 'fa fa-fw ' + icon; }
+  }
+}

--- a/config/test.exs
+++ b/config/test.exs
@@ -20,6 +20,7 @@ config :helheim, :chart_cache_ttl_ms, 0
 
 # Never cache external API responses across tests
 config :helheim, :api_cache_ttl_ms, 0
+config :helheim, :preview_url_cache_ttl_ms, 0
 
 # Print only warnings and errors during test
 config :logger, level: :warning

--- a/lib/helheim/deezer/client.ex
+++ b/lib/helheim/deezer/client.ex
@@ -1,7 +1,8 @@
 defmodule Helheim.Deezer.Client do
   @moduledoc """
   Thin Req based client for Deezer's public API (no authentication), used
-  as the fallback source for artist images when fanart.tv has none.
+  as the fallback source for artist images when fanart.tv has none, and as
+  the source of 30 second song previews.
   """
 
   @api_url "https://api.deezer.com"
@@ -25,6 +26,76 @@ defmodule Helheim.Deezer.Client do
         {:error, reason}
     end
   end
+
+  @doc """
+  Searches for the track by artist and title and returns its Deezer id,
+  but only for results whose artist matches case-insensitively and that
+  actually have a preview - linking the wrong song is worse than linking
+  none. Exact title matches win over Deezer's own relevance order, so
+  "Battery" is not beaten by "Battery (Live)".
+  """
+  def search_track(artist_name, title) do
+    query = ~s(artist:"#{strip_quotes(artist_name)}" track:"#{strip_quotes(title)}")
+
+    case Req.get("#{@api_url}/search/track", params: %{q: query}) do
+      {:ok, %Req.Response{body: %{"error" => %{"code" => 4}}}} ->
+        {:error, :rate_limited}
+      {:ok, %Req.Response{body: %{"error" => error}}} ->
+        {:error, {:api_error, error["code"], error["message"]}}
+      {:ok, %Req.Response{status: 200, body: %{"data" => data}}} when is_list(data) ->
+        find_track_match(data, artist_name, title)
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error, {:http_error, status, body}}
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Returns a playable preview URL for the track. Deezer preview URLs carry
+  an expiring hdnea token, so they must be resolved freshly rather than
+  stored. Retries are disabled and the receive timeout is short because
+  this call sits on a web request: Req's defaults (3 retries, 15s
+  timeout) would pin the request process while Deezer is slow or down.
+  """
+  def track_preview_url(deezer_id) do
+    case Req.get("#{@api_url}/track/#{deezer_id}", retry: false, receive_timeout: 5_000) do
+      {:ok, %Req.Response{body: %{"error" => %{"code" => 4}}}} ->
+        {:error, :rate_limited}
+      # A deleted or unknown track id is a 200 with error code 800 ("no
+      # data") - a miss rather than a failure, so callers can cache it.
+      {:ok, %Req.Response{body: %{"error" => %{"code" => 800}}}} ->
+        {:error, :not_found}
+      {:ok, %Req.Response{body: %{"error" => error}}} ->
+        {:error, {:api_error, error["code"], error["message"]}}
+      {:ok, %Req.Response{status: 200, body: %{"preview" => preview}}} ->
+        case present_url(preview) do
+          nil -> {:error, :not_found}
+          url -> {:ok, url}
+        end
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error, {:http_error, status, body}}
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp find_track_match(data, artist_name, title) do
+    candidates =
+      Enum.filter(data, fn track ->
+        String.downcase(get_in(track, ["artist", "name"]) || "") == String.downcase(artist_name) &&
+          present_url(track["preview"])
+      end)
+
+    exact = Enum.find(candidates, fn track -> String.downcase(track["title"] || "") == String.downcase(title) end)
+
+    case exact || List.first(candidates) do
+      nil -> {:error, :not_found}
+      track -> {:ok, %{deezer_id: track["id"]}}
+    end
+  end
+
+  defp strip_quotes(value), do: String.replace(value, "\"", "")
 
   defp find_exact_match(data, name) do
     data

--- a/lib/helheim/models/song.ex
+++ b/lib/helheim/models/song.ex
@@ -16,6 +16,7 @@ defmodule Helheim.Song do
     field :album_mbid,            :string
     field :release_year,          :integer
     field :duration_seconds,      :integer
+    field :deezer_id,             :integer
     field :enriched_at,           :utc_datetime_usec
     field :comment_count,         :integer
     field :listens_count,         :integer
@@ -28,7 +29,7 @@ defmodule Helheim.Song do
   end
 
   @metadata_fields [:album_name, :cover_image_url, :cover_image_url_small, :lastfm_track_url, :mbid, :artist_mbid, :album_mbid]
-  @enrichment_fields [:cover_image_url_large, :release_year, :duration_seconds, :enriched_at]
+  @enrichment_fields [:cover_image_url_large, :release_year, :duration_seconds, :deezer_id, :enriched_at]
 
   def changeset(struct, params \\ %{}) do
     struct

--- a/lib/helheim/music/enrichment.ex
+++ b/lib/helheim/music/enrichment.ex
@@ -12,6 +12,7 @@ defmodule Helheim.Music.Enrichment do
   alias Helheim.Repo
   alias Helheim.Song
   alias Helheim.Music.SongEnrichmentWorker
+  alias Helheim.Music.SongPreviewBackfillWorker
 
   def backfill do
     Song
@@ -20,6 +21,23 @@ defmodule Helheim.Music.Enrichment do
     |> Repo.all()
     |> Enum.map(fn song_id ->
       {:ok, _} = %{song_id: song_id} |> SongEnrichmentWorker.new() |> Oban.insert()
+    end)
+    |> length()
+  end
+
+  @doc """
+  Enqueues a preview-only Deezer lookup for every already-enriched song
+  still missing its deezer_id - the catalog that predates the preview
+  feature. Unenriched songs are skipped: their regular enrichment job
+  resolves the deezer_id itself.
+  """
+  def backfill_previews do
+    Song
+    |> where([s], not is_nil(s.enriched_at) and is_nil(s.deezer_id))
+    |> select([s], s.id)
+    |> Repo.all()
+    |> Enum.map(fn song_id ->
+      {:ok, _} = %{song_id: song_id} |> SongPreviewBackfillWorker.new() |> Oban.insert()
     end)
     |> length()
   end

--- a/lib/helheim/music/song_enrichment_worker.ex
+++ b/lib/helheim/music/song_enrichment_worker.ex
@@ -2,8 +2,8 @@ defmodule Helheim.Music.SongEnrichmentWorker do
   @moduledoc """
   Enriches a song with metadata beyond what the scrobble feed provides:
   MusicBrainz ids, duration, tags (the first doubling as the genre), a
-  higher resolution cover, the release year (via MusicBrainz) and a link
-  to its artist record.
+  higher resolution cover, the release year (via MusicBrainz), a Deezer
+  track id (for 30 second previews) and a link to its artist record.
 
   MusicBrainz calls are paced cluster-wide through Helheim.Musicbrainz.paced/1.
   Partial results are fine: enriched_at is stamped even when some sources
@@ -31,6 +31,7 @@ defmodule Helheim.Music.SongEnrichmentWorker do
   alias Helheim.Tag
   alias Helheim.Lastfm
   alias Helheim.Musicbrainz
+  alias Helheim.Deezer
   alias Helheim.Music.ArtistEnrichmentWorker
 
   @max_tags 5
@@ -58,11 +59,16 @@ defmodule Helheim.Music.SongEnrichmentWorker do
   defp enrich(song, force) do
     with {:ok, song, tags} <- apply_track_info(song),
          :ok <- apply_tags(song, tags),
+         {:ok, deezer_id} <- resolve_deezer_id(song, force),
          {:ok, release_year} <- resolve_release_year(song, force),
          {:ok, artist} <- ensure_artist(song) do
       {:ok, _} =
         song
-        |> Song.changeset(%{release_year: release_year || song.release_year, enriched_at: DateTime.utc_now()})
+        |> Song.changeset(%{
+          release_year: release_year || song.release_year,
+          deezer_id: deezer_id || song.deezer_id,
+          enriched_at: DateTime.utc_now()
+        })
         |> Ecto.Changeset.put_change(:artist_id, song.artist_id || artist.id)
         |> Repo.update()
 
@@ -221,6 +227,25 @@ defmodule Helheim.Music.SongEnrichmentWorker do
         {:ok, nil}
       error ->
         error
+    end
+  end
+
+  # The Deezer id powers the on-demand preview endpoint (preview URLs
+  # themselves expire, so only the id is stored). This step runs before
+  # the release year cascade on purpose: a Deezer rate limit then snoozes
+  # the job before any paced MusicBrainz work is spent (the retry does
+  # still repeat the Last.fm lookup - apply_track_info runs every
+  # attempt). Other Deezer errors degrade to "no preview" instead of
+  # gating the year/artist steps behind an optional field: a song settled
+  # during a Deezer hiccup keeps its core metadata, and
+  # mix helheim.preview_backfill re-checks any song still missing its
+  # deezer_id, so previews are recoverable in bulk.
+  defp resolve_deezer_id(%Song{deezer_id: deezer_id}, false) when is_integer(deezer_id), do: {:ok, deezer_id}
+  defp resolve_deezer_id(song, _force) do
+    case Deezer.Client.search_track(song.artist_name, song.title) do
+      {:ok, %{deezer_id: deezer_id}} -> {:ok, deezer_id}
+      {:error, :rate_limited} -> {:error, :rate_limited}
+      _ -> {:ok, nil}
     end
   end
 

--- a/lib/helheim/music/song_preview_backfill_worker.ex
+++ b/lib/helheim/music/song_preview_backfill_worker.ex
@@ -1,0 +1,65 @@
+defmodule Helheim.Music.SongPreviewBackfillWorker do
+  @moduledoc """
+  Backfills the Deezer id (and thereby the 30 second preview) for songs
+  that were enriched before previews existed - a single Deezer lookup,
+  without re-running the full Last.fm/MusicBrainz enrichment. A genuine
+  miss just leaves the song without a preview; because a miss is
+  indistinguishable from never-checked, re-running the backfill retries
+  misses, which is fine for a cheap one-off admin task.
+  """
+
+  use Oban.Worker,
+    queue: :enrichment,
+    # Deprioritized below regular enrichment (default priority 0) so a
+    # catalog-wide backfill cannot starve newly scrobbled songs on the
+    # concurrency-1 queue.
+    priority: 3,
+    max_attempts: 5,
+    unique: [
+      period: 3600,
+      keys: [:song_id],
+      states: [:available, :scheduled, :executing, :retryable, :suspended]
+    ]
+
+  require Logger
+  alias Helheim.Repo
+  alias Helheim.Song
+  alias Helheim.Deezer
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"song_id" => song_id}} = job) do
+    song = Repo.get(Song, song_id)
+
+    cond do
+      is_nil(song) -> :ok
+      song.deezer_id -> :ok
+      true -> song |> lookup() |> settle_final_attempt(job, song)
+    end
+  end
+
+  defp lookup(song) do
+    case Deezer.Client.search_track(song.artist_name, song.title) do
+      {:ok, %{deezer_id: deezer_id}} ->
+        {:ok, _} = song |> Song.changeset(%{deezer_id: deezer_id}) |> Repo.update()
+        :ok
+
+      {:error, :not_found} ->
+        :ok
+
+      {:error, :rate_limited} ->
+        {:snooze, 60}
+
+      error ->
+        error
+    end
+  end
+
+  # Unlike enrichment there is no flag to stamp: a job that still errors
+  # on its last attempt is simply logged and given up on - the next
+  # backfill run picks the song up again.
+  defp settle_final_attempt({:error, reason}, %Oban.Job{attempt: attempt, max_attempts: max}, song) when attempt >= max do
+    Logger.error("Preview backfill settled with error for song #{song.id}: #{inspect(reason)}")
+    :ok
+  end
+  defp settle_final_attempt(result, _job, _song), do: result
+end

--- a/lib/helheim_web/controllers/song_controller.ex
+++ b/lib/helheim_web/controllers/song_controller.ex
@@ -1,7 +1,9 @@
 defmodule HelheimWeb.SongController do
   use HelheimWeb, :controller
   alias Helheim.Block
+  alias Helheim.Cache
   alias Helheim.Comment
+  alias Helheim.Deezer
   alias Helheim.Song
   alias Helheim.SongListen
   alias Helheim.Music.Charts
@@ -66,6 +68,39 @@ defmodule HelheimWeb.SongController do
       recent_listens: recent_listens,
       comments: comments,
       current_user_has_listens: current_user_has_listens)
+  end
+
+  # Redirects to a playable 30 second preview MP3. Deezer preview URLs
+  # carry an expiring token, so only the track id is stored and the URL is
+  # resolved (and briefly cached) on demand.
+  def preview(conn, %{"song_id" => song_id}) do
+    song = Repo.get!(Song, song_id)
+
+    case resolve_preview_url(song) do
+      {:ok, url} -> redirect(conn, external: url)
+      _ -> send_resp(conn, :not_found, "")
+    end
+  end
+
+  defp resolve_preview_url(%Song{deezer_id: nil}), do: :error
+  defp resolve_preview_url(song) do
+    Cache.fetch(
+      {:deezer_preview, song.deezer_id},
+      preview_url_cache_ttl(),
+      fn -> Deezer.Client.track_preview_url(song.deezer_id) end,
+      cache_if: &cacheable_preview_result?/1
+    )
+  end
+
+  # Misses are cached too: a stale deezer_id (track since removed from
+  # Deezer) would otherwise turn every click into a live Deezer call.
+  # Transient failures (rate limits, outages) are not pinned.
+  defp cacheable_preview_result?({:ok, _}), do: true
+  defp cacheable_preview_result?({:error, :not_found}), do: true
+  defp cacheable_preview_result?(_), do: false
+
+  defp preview_url_cache_ttl do
+    Application.get_env(:helheim, :preview_url_cache_ttl_ms, :timer.hours(1))
   end
 
   def remove_my_listens(conn, %{"song_id" => song_id}) do

--- a/lib/helheim_web/router.ex
+++ b/lib/helheim_web/router.ex
@@ -137,6 +137,7 @@ defmodule HelheimWeb.Router do
       resources "/comments", CommentController, only: [:create, :edit, :update]
       resources "/notification_subscription", NotificationSubscriptionController, singleton: true, only: [:update]
       delete "/my_listens", SongController, :remove_my_listens, as: :my_listens
+      get "/preview", SongController, :preview, as: :preview
     end
   end
 

--- a/lib/helheim_web/templates/song/_listen.html.eex
+++ b/lib/helheim_web/templates/song/_listen.html.eex
@@ -1,5 +1,8 @@
 <div class="media mb-1">
-  <%= render "_cover.html", href: song_path(@conn, :show, @listen.song), image_url: @listen.song.cover_image_url_small %>
+  <div class="song-cover-frame">
+    <%= render "_cover.html", href: song_path(@conn, :show, @listen.song), image_url: @listen.song.cover_image_url_small %>
+    <%= preview_button @conn, @listen.song %>
+  </div>
   <div class="media-body">
     <%= link @listen.song.title, to: song_path(@conn, :show, @listen.song) %>
     <br>

--- a/lib/helheim_web/templates/song/_song.html.eex
+++ b/lib/helheim_web/templates/song/_song.html.eex
@@ -1,5 +1,8 @@
 <div class="media mb-1">
-  <%= render "_cover.html", href: song_path(@conn, :show, @song), image_url: @song.cover_image_url_small %>
+  <div class="song-cover-frame">
+    <%= render "_cover.html", href: song_path(@conn, :show, @song), image_url: @song.cover_image_url_small %>
+    <%= preview_button @conn, @song %>
+  </div>
   <div class="media-body">
     <%= link @song.title, to: song_path(@conn, :show, @song) %>
     <br>

--- a/lib/helheim_web/templates/song/show.html.eex
+++ b/lib/helheim_web/templates/song/show.html.eex
@@ -8,6 +8,7 @@
         <img class="card-img-top img-fluid" src="<%= detail_cover_url(@song) %>" alt="">
       <% end %>
       <div class="card-block">
+        <%= preview_button @conn, @song, class: "btn btn-sm btn-outline-primary btn-block mb-1", label: gettext("Play preview") %>
         <table class="table table-sm">
           <tr>
             <th><%= gettext "Artist" %></th>

--- a/lib/helheim_web/views/song_view.ex
+++ b/lib/helheim_web/views/song_view.ex
@@ -26,6 +26,27 @@ defmodule HelheimWeb.SongView do
   end
   def country_flag(_), do: nil
 
+  @doc """
+  A play/stop toggle for the song's 30 second preview, driven by
+  assets/js/song_preview.js. Renders nothing when the song has no Deezer
+  match. Defaults to the small overlay variant used on cover thumbnails;
+  pass `:class` and `:label` for a regular labelled button.
+  """
+  def preview_button(conn, song, opts \\ [])
+  def preview_button(_conn, %{deezer_id: nil}, _opts), do: nil
+  def preview_button(conn, song, opts) do
+    icon = content_tag(:i, "", class: "fa fa-fw fa-play")
+    content = if opts[:label], do: [icon, " ", opts[:label]], else: icon
+
+    content_tag(:button, content,
+      type: "button",
+      class: "song-preview-button #{Keyword.get(opts, :class, "song-preview-overlay")}",
+      title: gettext("Play preview"),
+      aria_label: gettext("Play preview"),
+      data: [preview_url: song_preview_path(conn, :preview, song)]
+    )
+  end
+
   def listen_count_badge(count) do
     content_tag :span, class: "badge badge-default" do
       [content_tag(:i, "", class: "fa fa-fw fa-headphones"), {:safe, [" #{count}"]}]

--- a/lib/mix/tasks/helheim.preview_backfill.ex
+++ b/lib/mix/tasks/helheim.preview_backfill.ex
@@ -1,0 +1,13 @@
+defmodule Mix.Tasks.Helheim.PreviewBackfill do
+  @moduledoc "Enqueues Deezer preview id lookups for already-enriched songs that have none."
+  @shortdoc "Backfills song preview ids from Deezer"
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+    count = Helheim.Music.Enrichment.backfill_previews()
+    Mix.shell().info("Enqueued preview backfill for #{count} songs")
+  end
+end

--- a/priv/gettext/da/LC_MESSAGES/default.po
+++ b/priv/gettext/da/LC_MESSAGES/default.po
@@ -2693,7 +2693,7 @@ msgstr "Er du sikker på at du vil slette dette fotoalbum? Alle billeder i album
 msgid "%{who} wrote a comment on the song: %{what}"
 msgstr "%{who} skrev en kommentar til sangen: %{what}"
 
-#: lib/helheim_web/templates/song/show.html.eex:18
+#: lib/helheim_web/templates/song/show.html.eex:19
 #, elixir-autogen, elixir-format
 msgid "Album"
 msgstr "Album"
@@ -2713,7 +2713,7 @@ msgstr "Er du sikker? Vi stopper med at registrere, hvad du lytter til. Din eksi
 msgid "Are you sure? Your entire listening history will be permanently deleted!"
 msgstr "Er du sikker? Hele din lyttehistorik bliver slettet permanent!"
 
-#: lib/helheim_web/templates/song/show.html.eex:13
+#: lib/helheim_web/templates/song/show.html.eex:14
 #, elixir-autogen, elixir-format
 msgid "Artist"
 msgstr "Kunstner"
@@ -2728,7 +2728,7 @@ msgstr "Slet lyttehistorik"
 msgid "Latest listens"
 msgstr "Seneste afspilninger"
 
-#: lib/helheim_web/templates/song/show.html.eex:35
+#: lib/helheim_web/templates/song/show.html.eex:36
 #, elixir-autogen, elixir-format
 msgid "Listens"
 msgstr "Afspilninger"
@@ -2746,12 +2746,12 @@ msgstr "Musik fra %{username}"
 msgid "No listens have been tracked yet..."
 msgstr "Der er ikke registreret nogen afspilninger endnu..."
 
-#: lib/helheim_web/templates/song/show.html.eex:72
+#: lib/helheim_web/templates/song/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "No one has listened to this song yet..."
 msgstr "Ingen har lyttet til denne sang endnu..."
 
-#: lib/helheim_web/templates/song/show.html.eex:70
+#: lib/helheim_web/templates/song/show.html.eex:71
 #, elixir-autogen, elixir-format
 msgid "Recent listeners"
 msgstr "Seneste lyttere"
@@ -2787,27 +2787,27 @@ msgstr "Du kan også slette hele din lyttehistorik fra siden. Dette kan ikke for
 msgid "Your listening history has been deleted."
 msgstr "Din lyttehistorik er blevet slettet."
 
-#: lib/helheim_web/templates/song/show.html.eex:57
+#: lib/helheim_web/templates/song/show.html.eex:58
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Your listens of this song will be permanently removed!"
 msgstr "Er du sikker? Dine afspilninger af denne sang bliver fjernet permanent!"
 
-#: lib/helheim_web/templates/song/show.html.eex:59
+#: lib/helheim_web/templates/song/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Remove my name from this song"
 msgstr "Fjern mit navn fra denne sang"
 
-#: lib/helheim_web/controllers/song_controller.ex:76
+#: lib/helheim_web/controllers/song_controller.ex:104
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr "Dine afspilninger er blevet fjernet fra denne sang."
 
-#: lib/helheim_web/templates/song/show.html.eex:51
+#: lib/helheim_web/templates/song/show.html.eex:52
 #, elixir-autogen, elixir-format
 msgid "Album on Last.fm"
 msgstr "Album på Last.fm"
 
-#: lib/helheim_web/templates/song/show.html.eex:48
+#: lib/helheim_web/templates/song/show.html.eex:49
 #, elixir-autogen, elixir-format
 msgid "Artist on Last.fm"
 msgstr "Kunstner på Last.fm"
@@ -2853,7 +2853,7 @@ msgstr "Forbind Last.fm igen"
 msgid "Set up scrobbling on Last.fm"
 msgstr "Opsæt scrobbling på Last.fm"
 
-#: lib/helheim_web/templates/song/show.html.eex:47
+#: lib/helheim_web/templates/song/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "Song on Last.fm"
 msgstr "Sang på Last.fm"
@@ -2891,24 +2891,31 @@ msgstr "Din Last.fm-konto er nu forbundet!"
 msgid "No songs have been listened to in this period yet..."
 msgstr "Der er ikke lyttet til nogen sange i denne periode endnu..."
 
-#: lib/helheim_web/controllers/song_controller.ex:24
+#: lib/helheim_web/controllers/song_controller.ex:26
 #: lib/helheim_web/templates/page/front_page.html.eex:96
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 24 hours"
 msgstr "Top sange, seneste 24 timer"
 
-#: lib/helheim_web/controllers/song_controller.ex:28
+#: lib/helheim_web/controllers/song_controller.ex:30
 #: lib/helheim_web/templates/page/front_page.html.eex:111
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 7 days"
 msgstr "Top sange, seneste 7 dage"
 
-#: lib/helheim_web/templates/song/show.html.eex:30
+#: lib/helheim_web/templates/song/show.html.eex:31
 #, elixir-autogen, elixir-format
 msgid "Genre"
 msgstr "Genre"
 
-#: lib/helheim_web/templates/song/show.html.eex:24
+#: lib/helheim_web/templates/song/show.html.eex:25
 #, elixir-autogen, elixir-format
 msgid "Year"
 msgstr "Årstal"
+
+#: lib/helheim_web/templates/song/show.html.eex:11
+#: lib/helheim_web/views/song_view.ex:44
+#: lib/helheim_web/views/song_view.ex:45
+#, elixir-autogen, elixir-format
+msgid "Play preview"
+msgstr "Hør smagsprøve"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2682,7 +2682,7 @@ msgstr ""
 msgid "%{who} wrote a comment on the song: %{what}"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:18
+#: lib/helheim_web/templates/song/show.html.eex:19
 #, elixir-autogen, elixir-format
 msgid "Album"
 msgstr ""
@@ -2702,7 +2702,7 @@ msgstr ""
 msgid "Are you sure? Your entire listening history will be permanently deleted!"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:13
+#: lib/helheim_web/templates/song/show.html.eex:14
 #, elixir-autogen, elixir-format
 msgid "Artist"
 msgstr ""
@@ -2717,7 +2717,7 @@ msgstr ""
 msgid "Latest listens"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:35
+#: lib/helheim_web/templates/song/show.html.eex:36
 #, elixir-autogen, elixir-format
 msgid "Listens"
 msgstr ""
@@ -2735,12 +2735,12 @@ msgstr ""
 msgid "No listens have been tracked yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:72
+#: lib/helheim_web/templates/song/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "No one has listened to this song yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:70
+#: lib/helheim_web/templates/song/show.html.eex:71
 #, elixir-autogen, elixir-format
 msgid "Recent listeners"
 msgstr ""
@@ -2776,27 +2776,27 @@ msgstr ""
 msgid "Your listening history has been deleted."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:57
+#: lib/helheim_web/templates/song/show.html.eex:58
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Your listens of this song will be permanently removed!"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:59
+#: lib/helheim_web/templates/song/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Remove my name from this song"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:76
+#: lib/helheim_web/controllers/song_controller.ex:104
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:51
+#: lib/helheim_web/templates/song/show.html.eex:52
 #, elixir-autogen, elixir-format
 msgid "Album on Last.fm"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:48
+#: lib/helheim_web/templates/song/show.html.eex:49
 #, elixir-autogen, elixir-format
 msgid "Artist on Last.fm"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Set up scrobbling on Last.fm"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:47
+#: lib/helheim_web/templates/song/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "Song on Last.fm"
 msgstr ""
@@ -2880,24 +2880,31 @@ msgstr ""
 msgid "No songs have been listened to in this period yet..."
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:24
+#: lib/helheim_web/controllers/song_controller.ex:26
 #: lib/helheim_web/templates/page/front_page.html.eex:96
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 24 hours"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:28
+#: lib/helheim_web/controllers/song_controller.ex:30
 #: lib/helheim_web/templates/page/front_page.html.eex:111
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 7 days"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:30
+#: lib/helheim_web/templates/song/show.html.eex:31
 #, elixir-autogen, elixir-format
 msgid "Genre"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:24
+#: lib/helheim_web/templates/song/show.html.eex:25
 #, elixir-autogen, elixir-format
 msgid "Year"
+msgstr ""
+
+#: lib/helheim_web/templates/song/show.html.eex:11
+#: lib/helheim_web/views/song_view.ex:44
+#: lib/helheim_web/views/song_view.ex:45
+#, elixir-autogen, elixir-format
+msgid "Play preview"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2682,7 +2682,7 @@ msgstr ""
 msgid "%{who} wrote a comment on the song: %{what}"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:18
+#: lib/helheim_web/templates/song/show.html.eex:19
 #, elixir-autogen, elixir-format
 msgid "Album"
 msgstr ""
@@ -2702,7 +2702,7 @@ msgstr ""
 msgid "Are you sure? Your entire listening history will be permanently deleted!"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:13
+#: lib/helheim_web/templates/song/show.html.eex:14
 #, elixir-autogen, elixir-format
 msgid "Artist"
 msgstr ""
@@ -2717,7 +2717,7 @@ msgstr ""
 msgid "Latest listens"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:35
+#: lib/helheim_web/templates/song/show.html.eex:36
 #, elixir-autogen, elixir-format
 msgid "Listens"
 msgstr ""
@@ -2735,12 +2735,12 @@ msgstr ""
 msgid "No listens have been tracked yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:72
+#: lib/helheim_web/templates/song/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "No one has listened to this song yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:70
+#: lib/helheim_web/templates/song/show.html.eex:71
 #, elixir-autogen, elixir-format
 msgid "Recent listeners"
 msgstr ""
@@ -2776,27 +2776,27 @@ msgstr ""
 msgid "Your listening history has been deleted."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:57
+#: lib/helheim_web/templates/song/show.html.eex:58
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure? Your listens of this song will be permanently removed!"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:59
+#: lib/helheim_web/templates/song/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Remove my name from this song"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:76
+#: lib/helheim_web/controllers/song_controller.ex:104
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:51
+#: lib/helheim_web/templates/song/show.html.eex:52
 #, elixir-autogen, elixir-format
 msgid "Album on Last.fm"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:48
+#: lib/helheim_web/templates/song/show.html.eex:49
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Artist on Last.fm"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Set up scrobbling on Last.fm"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:47
+#: lib/helheim_web/templates/song/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "Song on Last.fm"
 msgstr ""
@@ -2880,24 +2880,31 @@ msgstr ""
 msgid "No songs have been listened to in this period yet..."
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:24
+#: lib/helheim_web/controllers/song_controller.ex:26
 #: lib/helheim_web/templates/page/front_page.html.eex:96
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 24 hours"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:28
+#: lib/helheim_web/controllers/song_controller.ex:30
 #: lib/helheim_web/templates/page/front_page.html.eex:111
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Top songs, past 7 days"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:30
+#: lib/helheim_web/templates/song/show.html.eex:31
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Genre"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:24
+#: lib/helheim_web/templates/song/show.html.eex:25
 #, elixir-autogen, elixir-format
 msgid "Year"
+msgstr ""
+
+#: lib/helheim_web/templates/song/show.html.eex:11
+#: lib/helheim_web/views/song_view.ex:44
+#: lib/helheim_web/views/song_view.ex:45
+#, elixir-autogen, elixir-format
+msgid "Play preview"
 msgstr ""

--- a/priv/repo/migrations/20260716000001_add_deezer_id_to_songs.exs
+++ b/priv/repo/migrations/20260716000001_add_deezer_id_to_songs.exs
@@ -1,0 +1,9 @@
+defmodule Helheim.Repo.Migrations.AddDeezerIdToSongs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:songs) do
+      add :deezer_id, :bigint
+    end
+  end
+end

--- a/test/helheim/music/enrichment_test.exs
+++ b/test/helheim/music/enrichment_test.exs
@@ -3,6 +3,7 @@ defmodule Helheim.Music.EnrichmentTest do
   use Oban.Testing, repo: Helheim.Repo
   alias Helheim.Music.Enrichment
   alias Helheim.Music.SongEnrichmentWorker
+  alias Helheim.Music.SongPreviewBackfillWorker
 
   describe "backfill/0" do
     test "enqueues enrichment for every unenriched song" do
@@ -23,6 +24,28 @@ defmodule Helheim.Music.EnrichmentTest do
       assert Enrichment.backfill() == 1
       assert Enrichment.backfill() == 1
       assert length(all_enqueued(worker: SongEnrichmentWorker)) == 1
+    end
+  end
+
+  describe "backfill_previews/0" do
+    test "enqueues a preview lookup only for enriched songs without a deezer id" do
+      missing = insert(:song, enriched_at: DateTime.utc_now(), deezer_id: nil)
+      has_preview = insert(:song, enriched_at: DateTime.utc_now(), deezer_id: 424_565_222)
+      unenriched = insert(:song, enriched_at: nil, deezer_id: nil)
+
+      assert Enrichment.backfill_previews() == 1
+
+      assert_enqueued worker: SongPreviewBackfillWorker, args: %{song_id: missing.id}
+      refute_enqueued worker: SongPreviewBackfillWorker, args: %{song_id: has_preview.id}
+      refute_enqueued worker: SongPreviewBackfillWorker, args: %{song_id: unenriched.id}
+    end
+
+    test "is idempotent thanks to job uniqueness" do
+      insert(:song, enriched_at: DateTime.utc_now(), deezer_id: nil)
+
+      assert Enrichment.backfill_previews() == 1
+      assert Enrichment.backfill_previews() == 1
+      assert length(all_enqueued(worker: SongPreviewBackfillWorker)) == 1
     end
   end
 end

--- a/test/helheim/music/song_enrichment_worker_test.exs
+++ b/test/helheim/music/song_enrichment_worker_test.exs
@@ -9,6 +9,7 @@ defmodule Helheim.Music.SongEnrichmentWorkerTest do
   alias Helheim.Tag
   alias Helheim.Lastfm
   alias Helheim.Musicbrainz
+  alias Helheim.Deezer
   alias Helheim.Music.ArtistEnrichmentWorker
   alias Helheim.Music.SongEnrichmentWorker
 
@@ -40,7 +41,8 @@ defmodule Helheim.Music.SongEnrichmentWorkerTest do
         recording: fn _mbid -> {:ok, %{"first-release-date" => "1986-03-03"}} end,
         release: fn _mbid -> {:ok, %{"release-group" => %{"first-release-date" => "1986"}}} end,
         search_recording: fn _artist, _title -> {:ok, [%{"first-release-date" => "1986-03-03"}]} end
-      ]}
+      ]},
+      {Deezer.Client, [:passthrough], [search_track: fn _artist, _title -> {:ok, %{deezer_id: 424_565_222}} end]}
     ]) do
       :ok
     end
@@ -57,6 +59,7 @@ defmodule Helheim.Music.SongEnrichmentWorkerTest do
       assert song.duration_seconds == 315
       assert song.release_year == 1986
       assert song.cover_image_url_large == "https://lastfm.freetls.fastly.net/i/u/500x500/abc.jpg"
+      assert song.deezer_id == 424_565_222
       assert song.enriched_at
       assert Enum.map(song.tags, & &1.name) |> Enum.sort() == ["80s", "metal", "thrash metal"]
 
@@ -67,7 +70,7 @@ defmodule Helheim.Music.SongEnrichmentWorkerTest do
     end
 
     test "does not clobber values the song already has" do
-      song = insert_unenriched_song(mbid: "existing-mbid", album_name: "Existing Album", duration_seconds: 100)
+      song = insert_unenriched_song(mbid: "existing-mbid", album_name: "Existing Album", duration_seconds: 100, deezer_id: 111)
 
       assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
 
@@ -75,6 +78,44 @@ defmodule Helheim.Music.SongEnrichmentWorkerTest do
       assert song.mbid == "existing-mbid"
       assert song.album_name == "Existing Album"
       assert song.duration_seconds == 100
+      assert song.deezer_id == 111
+      assert not called Deezer.Client.search_track(:_, :_)
+    end
+
+    test "leaves the deezer id empty when deezer has no match but still marks the song enriched" do
+      song = insert_unenriched_song()
+
+      with_mock Deezer.Client, [:passthrough], [search_track: fn _a, _t -> {:error, :not_found} end] do
+        assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+      end
+
+      song = Repo.get(Song, song.id)
+      assert song.deezer_id == nil
+      assert song.enriched_at
+    end
+
+    test "continues without a deezer id when deezer errors, keeping the rest of the enrichment" do
+      song = insert_unenriched_song()
+
+      with_mock Deezer.Client, [:passthrough], [search_track: fn _a, _t -> {:error, {:http_error, 500, ""}} end] do
+        assert :ok = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+      end
+
+      song = Repo.get(Song, song.id)
+      assert song.deezer_id == nil
+      assert song.enriched_at
+      assert song.release_year == 1986
+      assert song.artist_id
+    end
+
+    test "snoozes when deezer rate limits" do
+      song = insert_unenriched_song()
+
+      with_mock Deezer.Client, [:passthrough], [search_track: fn _a, _t -> {:error, :rate_limited} end] do
+        assert {:snooze, 60} = perform_job(SongEnrichmentWorker, %{song_id: song.id})
+      end
+
+      refute Repo.get(Song, song.id).enriched_at
     end
 
     test "skips songs that are already enriched" do
@@ -193,7 +234,8 @@ defmodule Helheim.Music.SongEnrichmentWorkerTest do
 
   describe "release year cascade" do
     setup_with_mocks([
-      {Lastfm.Client, [:passthrough], [track_info: fn _artist, _title -> @track_info end]}
+      {Lastfm.Client, [:passthrough], [track_info: fn _artist, _title -> @track_info end]},
+      {Deezer.Client, [:passthrough], [search_track: fn _artist, _title -> {:error, :not_found} end]}
     ]) do
       :ok
     end

--- a/test/helheim/music/song_preview_backfill_worker_test.exs
+++ b/test/helheim/music/song_preview_backfill_worker_test.exs
@@ -1,0 +1,71 @@
+defmodule Helheim.Music.SongPreviewBackfillWorkerTest do
+  use Helheim.DataCase
+  use Oban.Testing, repo: Helheim.Repo
+  import Mock
+  alias Helheim.Repo
+  alias Helheim.Song
+  alias Helheim.Deezer
+  alias Helheim.Music.SongPreviewBackfillWorker
+
+  defp insert_enriched_song_without_preview(attrs \\ []) do
+    insert(:song, Keyword.merge([enriched_at: DateTime.utc_now(), deezer_id: nil], attrs))
+  end
+
+  describe "perform/1" do
+    test "stores the deezer id without touching the rest of the enrichment" do
+      song = insert_enriched_song_without_preview(release_year: 1986)
+
+      with_mock Deezer.Client, [:passthrough], [search_track: fn "Metallica", _title -> {:ok, %{deezer_id: 424_565_222}} end] do
+        assert :ok = perform_job(SongPreviewBackfillWorker, %{song_id: song.id})
+      end
+
+      song = Repo.get(Song, song.id)
+      assert song.deezer_id == 424_565_222
+      assert song.release_year == 1986
+    end
+
+    test "leaves the song alone when deezer has no match" do
+      song = insert_enriched_song_without_preview()
+
+      with_mock Deezer.Client, [:passthrough], [search_track: fn _a, _t -> {:error, :not_found} end] do
+        assert :ok = perform_job(SongPreviewBackfillWorker, %{song_id: song.id})
+      end
+
+      assert Repo.get(Song, song.id).deezer_id == nil
+    end
+
+    test "skips songs that already have a deezer id" do
+      song = insert_enriched_song_without_preview(deezer_id: 111)
+
+      with_mock Deezer.Client, [:passthrough], [search_track: fn _a, _t -> {:ok, %{deezer_id: 222}} end] do
+        assert :ok = perform_job(SongPreviewBackfillWorker, %{song_id: song.id})
+        assert not called Deezer.Client.search_track(:_, :_)
+      end
+
+      assert Repo.get(Song, song.id).deezer_id == 111
+    end
+
+    test "skips songs that no longer exist" do
+      assert :ok = perform_job(SongPreviewBackfillWorker, %{song_id: 1_234_567})
+    end
+
+    test "snoozes when deezer rate limits" do
+      song = insert_enriched_song_without_preview()
+
+      with_mock Deezer.Client, [:passthrough], [search_track: fn _a, _t -> {:error, :rate_limited} end] do
+        assert {:snooze, 60} = perform_job(SongPreviewBackfillWorker, %{song_id: song.id})
+      end
+    end
+
+    test "retries transient errors and gives up quietly on the final attempt" do
+      song = insert_enriched_song_without_preview()
+
+      with_mock Deezer.Client, [:passthrough], [search_track: fn _a, _t -> {:error, {:http_error, 500, ""}} end] do
+        assert {:error, _} = perform_job(SongPreviewBackfillWorker, %{song_id: song.id}, attempt: 1)
+        assert :ok = perform_job(SongPreviewBackfillWorker, %{song_id: song.id}, attempt: 5)
+      end
+
+      assert Repo.get(Song, song.id).deezer_id == nil
+    end
+  end
+end

--- a/test/helheim_web/controllers/song_controller_test.exs
+++ b/test/helheim_web/controllers/song_controller_test.exs
@@ -1,5 +1,7 @@
 defmodule HelheimWeb.SongControllerTest do
   use HelheimWeb.ConnCase
+  import Mock
+  alias Helheim.Deezer
 
   ##############################################################################
   # recent/2
@@ -168,6 +170,22 @@ defmodule HelheimWeb.SongControllerTest do
       assert response =~ "500x500"
     end
 
+    test "it shows a preview button when the song has a deezer id", %{conn: conn} do
+      song = insert(:song, deezer_id: 424_565_222)
+
+      conn = get conn, "/songs/#{song.id}"
+      response = html_response(conn, 200)
+      assert response =~ "song-preview-button"
+      assert response =~ "/songs/#{song.id}/preview"
+    end
+
+    test "it does not show a preview button when the song has no deezer id", %{conn: conn} do
+      song = insert(:song, deezer_id: nil)
+
+      conn = get conn, "/songs/#{song.id}"
+      refute html_response(conn, 200) =~ "song-preview-button"
+    end
+
     test "it shows the comments of the song", %{conn: conn} do
       comment = insert(:song_comment, body: "What a fantastic track")
 
@@ -186,6 +204,53 @@ defmodule HelheimWeb.SongControllerTest do
     test "it redirects to the sign in page", %{conn: conn} do
       song = insert(:song)
       conn = get conn, "/songs/#{song.id}"
+      assert redirected_to(conn) =~ session_path(conn, :new)
+    end
+  end
+
+  ##############################################################################
+  # preview/2
+  describe "preview/2 when signed in" do
+    setup [:create_and_sign_in_user]
+
+    test "it redirects to a freshly resolved deezer preview url", %{conn: conn} do
+      song = insert(:song, deezer_id: 424_565_222)
+
+      with_mock Deezer.Client, [:passthrough], [
+        track_preview_url: fn 424_565_222 -> {:ok, "https://cdnt-preview.dzcdn.net/api/1/1/abc.mp3?hdnea=exp=123"} end
+      ] do
+        conn = get conn, "/songs/#{song.id}/preview"
+        assert redirected_to(conn) == "https://cdnt-preview.dzcdn.net/api/1/1/abc.mp3?hdnea=exp=123"
+      end
+    end
+
+    test "it returns a 404 when the song has no deezer id", %{conn: conn} do
+      song = insert(:song, deezer_id: nil)
+
+      conn = get conn, "/songs/#{song.id}/preview"
+      assert response(conn, 404)
+    end
+
+    test "it returns a 404 when deezer cannot resolve the preview", %{conn: conn} do
+      song = insert(:song, deezer_id: 424_565_222)
+
+      with_mock Deezer.Client, [:passthrough], [track_preview_url: fn _id -> {:error, :not_found} end] do
+        conn = get conn, "/songs/#{song.id}/preview"
+        assert response(conn, 404)
+      end
+    end
+
+    test "it returns a 404 when the song does not exist", %{conn: conn} do
+      assert_error_sent :not_found, fn ->
+        get conn, "/songs/1234567/preview"
+      end
+    end
+  end
+
+  describe "preview/2 when not signed in" do
+    test "it redirects to the sign in page", %{conn: conn} do
+      song = insert(:song, deezer_id: 424_565_222)
+      conn = get conn, "/songs/#{song.id}/preview"
       assert redirected_to(conn) =~ session_path(conn, :new)
     end
   end


### PR DESCRIPTION
## What

Adds in-place 30 second song previews to the music tracking feature — a play button on cover thumbnails (recent listens, top-song lists, user music pages) and on the song detail page, with no click-out to Last.fm or Deezer needed.

- **Data**: songs gain a `deezer_id`, resolved during enrichment via Deezer's public track search (exact artist match required, exact title preferred over Deezer's relevance order so "Battery" beats "Battery (Live)").
- **Playback**: Deezer preview URLs carry an expiring `hdnea` token (verified live: ~10–15h validity), so only the id is stored. A new `GET /songs/:id/preview` endpoint resolves a fresh URL on demand — cached 1 hour via `Helheim.Cache`, misses cached too — and 302-redirects to the MP3. A small vanilla JS module (`song_preview.js`) plays it: one preview at a time, play/stop toggle, spinner while loading.
- **Backfill**: songs enriched before this feature never get revisited by the sweep, so `mix helheim.preview_backfill` + `SongPreviewBackfillWorker` look up just the Deezer id for the existing catalog (no Last.fm/MusicBrainz re-run). **Run the mix task once after deploying** to light up previews on the back catalog.

## Why

Listening history is browseable but songs weren't hearable without leaving the site. Deezer was already a dependency (artist image fallback) and its track search returns previews with no auth, so this stays within the existing provider set.

## Review notes

Two max-effort review rounds ran against this diff; the confirmed high-impact findings were fixed in place:

- Deezer answers deleted track ids with HTTP 200 + error code 800, not an empty result — mapped to `:not_found` so the endpoint's negative cache actually engages for stale ids (verified against the live API).
- The endpoint's Deezer call uses `retry: false` + 5s `receive_timeout` so a slow/down Deezer can't pin web request processes.
- Deezer failures during enrichment degrade to "no preview" rather than gating release-year/artist resolution; the backfill task is the bulk recovery path. The Deezer step runs before the paced MusicBrainz cascade so rate-limit snoozes don't waste MusicBrainz budget.
- Backfill jobs run at Oban `priority: 3` so a catalog-wide run can't starve fresh enrichment on the concurrency-1 queue.

Known accepted trade-offs (all reviewed, deliberately not blocking): the 1h URL cache assumes Deezer tokens stay valid longer than an hour (currently ~10–15h); a stale `deezer_id` isn't cleared by force re-enrichment; a Deezer miss is indistinguishable from never-checked, so backfill re-runs re-query misses.

## Testing

- 1576 tests green (76 in the touched areas, 8 new: backfill worker, backfill enqueue, preview endpoint, button rendering, enrichment error paths).
- Verified end-to-end in the running app: button renders with Danish translation ("Hør smagsprøve"), audio streams, play/stop and one-at-a-time behavior work, 404s for songs without a Deezer match, and the live Oban pipeline enriched 14 newly scrobbled songs with Deezer ids unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)