### PR TITLE
Add song upvotes with async voting and front page charts

### DIFF
--- a/assets/css/_custom.scss
+++ b/assets/css/_custom.scss
@@ -311,6 +311,23 @@ code {
 }
 
 
+// Inline SVG icon (the hand-horns upvote glyph is not in Font Awesome's
+// free set), sized to line up with the fixed-width font icons in badges.
+.icon-horns {
+  width: 1.28571em;
+  height: 1em;
+  vertical-align: -0.125em;
+  fill: currentColor;
+}
+
+// The upvote toggle is a <button> styled as a badge; strip the native
+// button chrome so it renders exactly like the neighbouring count badges.
+.song-upvote-button {
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+}
+
 .song-cover-frame {
   position: relative;
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -46,6 +46,7 @@ import { PreferencesForm } from "./preferences_form";
 import { BlockForm } from "./block_form";
 import { IgnoreForm } from "./ignore_form";
 import { SongPreview } from "./song_preview";
+import { SongUpvote } from "./song_upvote";
 
 import css from "../css/app.css.scss"
 
@@ -73,6 +74,7 @@ export var App = {
     BlockForm.run();
     IgnoreForm.run();
     SongPreview.run();
+    SongUpvote.run();
   }
 }
 

--- a/assets/js/song_upvote.js
+++ b/assets/js/song_upvote.js
@@ -1,0 +1,79 @@
+// Asynchronously toggles song upvotes via the badge buttons rendered by
+// HelheimWeb.SongView.upvote_toggle/3, without a full page load. The
+// server responds with the resulting state and all-time count, and every
+// badge for the same song on the page is snapped to it - the toggle
+// always shows the total, so the server's count can simply overwrite
+// whatever is displayed (windowed chart counts live in separate,
+// non-interactive badges).
+//
+// A session that expired while the page was open would otherwise fail
+// invisibly (the fetch follows the auth redirect and gets the sign-in
+// page), so redirected responses navigate there instead; other failures
+// briefly flash the button red.
+export var SongUpvote = {
+  run: function(){
+    const buttons = document.querySelectorAll('.song-upvote-button');
+
+    for (let i = 0; i < buttons.length; i++) {
+      buttons[i].addEventListener('click', (event) => {
+        event.preventDefault();
+        this.toggle(event.currentTarget);
+      });
+    }
+  },
+
+  toggle: function(button){
+    if (button.dataset.busy) { return; }
+    button.dataset.busy = 'true';
+    const upvoted = button.dataset.upvoted === 'true';
+
+    fetch(button.dataset.upvoteUrl, {
+      method: upvoted ? 'DELETE' : 'POST',
+      headers: {
+        'x-csrf-token': this.csrfToken(),
+        'accept': 'application/json'
+      },
+      credentials: 'same-origin'
+    })
+      .then((response) => {
+        if (response.redirected) {
+          window.location.href = response.url;
+          return null;
+        }
+        if (!response.ok) { throw new Error('upvote failed: ' + response.status); }
+        return response.json();
+      })
+      .then((data) => { if (data) { this.sync(button.dataset.songId, data); } })
+      .catch(() => { this.flashError(button); })
+      .finally(() => { delete button.dataset.busy; });
+  },
+
+  sync: function(songId, data){
+    const buttons = document.querySelectorAll('.song-upvote-button[data-song-id="' + songId + '"]');
+
+    for (let i = 0; i < buttons.length; i++) {
+      const button = buttons[i];
+
+      button.dataset.upvoted = String(data.upvoted);
+      button.classList.toggle('badge-primary', data.upvoted);
+      button.classList.toggle('badge-default', !data.upvoted);
+
+      const title = data.upvoted ? button.dataset.titleRemove : button.dataset.titleUpvote;
+      button.title = title;
+      button.setAttribute('aria-label', title);
+      button.setAttribute('aria-pressed', String(data.upvoted));
+
+      const count = button.querySelector('.song-upvote-count');
+      if (count) { count.textContent = data.upvotes_count; }
+    }
+  },
+
+  flashError: function(button){
+    button.classList.add('badge-danger');
+    setTimeout(() => { button.classList.remove('badge-danger'); }, 1500);
+  },
+
+  csrfToken: function(){
+    return document.body.dataset.csrf || '';
+  }
+}

--- a/lib/helheim/cache.ex
+++ b/lib/helheim/cache.ex
@@ -2,6 +2,12 @@ defmodule Helheim.Cache do
   @moduledoc """
   Minimal ETS backed read-through cache for values that are expensive to
   compute but may be slightly stale, such as the front page music charts.
+
+  Keys are tuples whose first element names the cache, e.g.
+  `{:top_songs_last_day, 5}` - `invalidate/1` drops every entry sharing
+  that first element. The cache is node-local: in a multi-node deployment
+  each node caches (and invalidates) independently, so cross-node
+  staleness is bounded only by the entry's ttl.
   """
 
   use GenServer
@@ -32,6 +38,18 @@ defmodule Helheim.Cache do
     end
   end
 
+  @doc """
+  Removes all cached entries whose key is a tuple starting with `prefix`,
+  e.g. `invalidate(:top_songs_last_day)` drops the entry for every count.
+  Also bumps the prefix's generation so a computation already in flight
+  when the invalidation happened cannot re-insert its (stale) result.
+  """
+  def invalidate(prefix) do
+    :ets.update_counter(@table, {:generation, prefix}, 1, {{:generation, prefix}, 0})
+    :ets.match_delete(@table, {{prefix, :_}, :_, :_})
+    :ok
+  end
+
   defp lookup(key, fun, ttl_ms, cache_if) do
     now = System.monotonic_time(:millisecond)
 
@@ -39,9 +57,24 @@ defmodule Helheim.Cache do
       [{^key, value, expires_at}] when expires_at > now ->
         value
       _ ->
+        generation = generation(key)
         value = fun.()
-        if cache_if.(value), do: :ets.insert(@table, {key, value, now + ttl_ms})
+
+        if cache_if.(value) and generation(key) == generation do
+          :ets.insert(@table, {key, value, now + ttl_ms})
+        end
+
         value
     end
   end
+
+  defp generation(key) do
+    case :ets.lookup(@table, {:generation, cache_prefix(key)}) do
+      [{_key, generation}] -> generation
+      [] -> 0
+    end
+  end
+
+  defp cache_prefix(key) when is_tuple(key), do: elem(key, 0)
+  defp cache_prefix(key), do: key
 end

--- a/lib/helheim/models/song.ex
+++ b/lib/helheim/models/song.ex
@@ -20,9 +20,11 @@ defmodule Helheim.Song do
     field :enriched_at,           :utc_datetime_usec
     field :comment_count,         :integer
     field :listens_count,         :integer
+    field :upvotes_count,         :integer
     belongs_to :artist, Helheim.Artist
     has_many :listens, SongListen
     has_many :comments, Helheim.Comment
+    has_many :upvotes, Helheim.SongUpvote
     has_many :song_tags, Helheim.SongTag
     has_many :tags, through: [:song_tags, :tag]
     timestamps(type: :utc_datetime_usec)
@@ -54,6 +56,20 @@ defmodule Helheim.Song do
   def top_by_listens_since(query, since, excluded_user_ids) do
     from [s, l] in top_by_listens_since(query, since),
       where: l.user_id not in ^excluded_user_ids
+  end
+
+  def top_by_upvotes_since(query, since, excluded_user_ids \\ nil)
+  def top_by_upvotes_since(query, since, excluded_user_ids) when excluded_user_ids in [nil, []] do
+    from s in query,
+      join: u in Helheim.SongUpvote, on: u.song_id == s.id,
+      where: u.inserted_at >= ^since,
+      group_by: s.id,
+      order_by: [desc: count(u.id), asc: s.id],
+      select: {s, count(u.id)}
+  end
+  def top_by_upvotes_since(query, since, excluded_user_ids) do
+    from [s, u] in top_by_upvotes_since(query, since),
+      where: u.user_id not in ^excluded_user_ids
   end
 
   def top_for_user(query, user) do

--- a/lib/helheim/models/song_upvote.ex
+++ b/lib/helheim/models/song_upvote.ex
@@ -1,0 +1,23 @@
+defmodule Helheim.SongUpvote do
+  use Helheim, :model
+
+  schema "song_upvotes" do
+    belongs_to :user, Helheim.User
+    belongs_to :song, Helheim.Song
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def changeset(struct) do
+    struct
+    |> change()
+    |> unique_constraint(:user_id, name: :song_upvotes_user_id_song_id_index)
+  end
+
+  def for_user(query, user) do
+    from u in query, where: u.user_id == ^user.id
+  end
+
+  def for_song(query, song) do
+    from u in query, where: u.song_id == ^song.id
+  end
+end

--- a/lib/helheim/models/user.ex
+++ b/lib/helheim/models/user.ex
@@ -322,10 +322,18 @@ defmodule Helheim.User do
   def delete!(user) do
     photo_albums = assoc(user, :photo_albums) |> Repo.all
     Parallel.pmap(photo_albums, fn(pa) -> Helheim.PhotoAlbum.delete!(pa) end)
-    # The song_listens rows cascade with the user, so decrement the song
-    # listen counters first to keep them in sync
-    {:ok, _} = Helheim.LastfmAccountService.delete_history!(user)
-    Repo.delete!(user)
+    # The song_listens and song_upvotes rows cascade with the user, so
+    # decrement the song counters first to keep them in sync. One
+    # transaction with the user delete itself, so a failed delete cannot
+    # leave the listens or upvotes half-removed.
+    {:ok, deleted_user} =
+      Repo.transaction(fn ->
+        {:ok, _} = Helheim.LastfmAccountService.delete_history!(user)
+        {:ok, _} = Helheim.SongUpvoteService.delete_upvotes_for_user!(user)
+        Repo.delete!(user)
+      end)
+
+    deleted_user
   end
 
   def age(%User{birthday: nil}, _), do: nil

--- a/lib/helheim/music/charts.ex
+++ b/lib/helheim/music/charts.ex
@@ -1,12 +1,13 @@
 defmodule Helheim.Music.Charts do
   @moduledoc """
-  Aggregated listening statistics for the front page, based on rolling
-  windows: the past 24 hours and the past 7 days.
+  Aggregated listening and upvote statistics for the front page, based on
+  rolling windows: the past 24 hours and the past 7 days.
 
-  Listens from `excluded_user_ids` (the viewer's ignore list) are left out
-  of the charts. The unfiltered charts are cached for a short interval since
-  they are recomputed on every front page render; personalized results for
-  viewers who actually ignore someone are computed directly.
+  Listens and upvotes from `excluded_user_ids` (the viewer's ignore list)
+  are left out of the charts. The unfiltered charts are cached for a short
+  interval since they are recomputed on every front page render;
+  personalized results for viewers who actually ignore someone are computed
+  directly.
   """
 
   import Ecto.Query
@@ -23,9 +24,25 @@ defmodule Helheim.Music.Charts do
   end
 
   def top_songs_since(since, count, excluded_user_ids \\ nil, opts \\ []) do
+    top_songs(&Song.top_by_listens_since/3, since, count, excluded_user_ids, opts)
+  end
+
+  def top_upvoted_songs_last_day(count, excluded_user_ids \\ nil) do
+    top_upvoted_songs_since(hours_ago(24), count, excluded_user_ids, cache_key: {:top_upvoted_songs_last_day, count})
+  end
+
+  def top_upvoted_songs_last_week(count, excluded_user_ids \\ nil) do
+    top_upvoted_songs_since(hours_ago(24 * 7), count, excluded_user_ids, cache_key: {:top_upvoted_songs_last_week, count})
+  end
+
+  def top_upvoted_songs_since(since, count, excluded_user_ids \\ nil, opts \\ []) do
+    top_songs(&Song.top_by_upvotes_since/3, since, count, excluded_user_ids, opts)
+  end
+
+  defp top_songs(chart_fun, since, count, excluded_user_ids, opts) do
     query = fn ->
       Song
-      |> Song.top_by_listens_since(since, excluded_user_ids)
+      |> chart_fun.(since, excluded_user_ids)
       |> limit(^count)
       |> Repo.all()
     end
@@ -37,6 +54,25 @@ defmodule Helheim.Music.Charts do
     else
       query.()
     end
+  end
+
+  @doc """
+  Drops every cached chart on this node so the next render recomputes.
+
+  Called when a vote is cast or removed: the upvote charts genuinely
+  reorder, and the listen charts are included too because their cached
+  rows embed `Song` structs whose `upvotes_count` the upvote badges
+  display. This deliberately trades cache efficiency for freshness - under
+  heavy vote traffic the recompute rate scales with the vote rate instead
+  of being capped by the ttl. If chart queries ever show up in monitoring,
+  the listen charts can be dropped from this list at the cost of vote
+  counts inside them lagging up to one ttl.
+  """
+  def invalidate_cache do
+    Enum.each(
+      [:top_songs_last_day, :top_songs_last_week, :top_upvoted_songs_last_day, :top_upvoted_songs_last_week],
+      &Cache.invalidate/1
+    )
   end
 
   def hours_ago(hours) do

--- a/lib/helheim/services/song_upvote_service.ex
+++ b/lib/helheim/services/song_upvote_service.ex
@@ -1,0 +1,113 @@
+defmodule Helheim.SongUpvoteService do
+  @moduledoc """
+  Toggling a user's upvote on a song, keeping the cached `upvotes_count` on
+  the song in sync. A user can upvote a song at most once - enforced by a
+  unique index on `(user_id, song_id)` - so a duplicate upvote fails with
+  `{:error, :song_upvote, changeset, _}` and leaves the count untouched,
+  and removing an upvote that is not there is a no-op.
+
+  Successful toggles invalidate the cached song charts (see
+  `Helheim.Music.Charts.invalidate_cache/0`) so the next render on this
+  node reflects the vote immediately.
+  """
+
+  import Ecto.Query
+  alias Ecto.Changeset
+  alias Ecto.Multi
+  alias Helheim.Music.Charts
+  alias Helheim.Repo
+  alias Helheim.Song
+  alias Helheim.SongListen
+  alias Helheim.SongUpvote
+
+  def upvote!(song, user) do
+    Multi.new
+    |> Multi.insert(:song_upvote, build_upvote(song, user))
+    |> Multi.update_all(:upvotes_count, (Song |> where(id: ^song.id)), inc: [upvotes_count: 1])
+    |> Repo.transaction
+    |> invalidate_charts()
+  end
+
+  def remove_upvote!(song, user) do
+    Multi.new
+    |> Multi.delete_all(:song_upvote, (SongUpvote |> SongUpvote.for_user(user) |> SongUpvote.for_song(song)))
+    |> dec_upvotes_count(song)
+    |> Repo.transaction
+    |> invalidate_charts()
+  end
+
+  @doc """
+  Deletes all of the user's upvotes and keeps the song upvote counters in
+  sync. Used when the user account is deleted, before the FK cascade would
+  otherwise remove the rows without touching the counters.
+  """
+  def delete_upvotes_for_user!(user) do
+    upvotes_query = from u in SongUpvote, where: u.user_id == ^user.id
+
+    counts_query =
+      from u in subquery(upvotes_query),
+        group_by: u.song_id,
+        select: %{song_id: u.song_id, upvote_count: count(u.id)}
+
+    dec_query =
+      from s in Song,
+        join: c in subquery(counts_query), on: c.song_id == s.id,
+        update: [set: [upvotes_count: s.upvotes_count - c.upvote_count]]
+
+    Multi.new()
+    |> Multi.update_all(:dec_upvotes_counts, dec_query, [])
+    |> Multi.delete_all(:delete_upvotes, upvotes_query)
+    |> Repo.transaction()
+    |> invalidate_charts()
+  end
+
+  @doc """
+  Given a user and a collection of songs - as `Song` structs, song ids,
+  `{song, count}` chart rows, or `SongListen`s, in any combination -
+  returns the ids of those songs the user has upvoted. Lets a listing
+  render the correct button state with a single query instead of one per
+  song.
+  """
+  def upvoted_song_ids(nil, _items), do: []
+  def upvoted_song_ids(user, items) do
+    case items |> Enum.map(&song_id/1) |> Enum.uniq() do
+      [] ->
+        []
+      song_ids ->
+        SongUpvote
+        |> SongUpvote.for_user(user)
+        |> where([u], u.song_id in ^song_ids)
+        |> select([u], u.song_id)
+        |> Repo.all
+    end
+  end
+
+  defp song_id(%Song{id: id}), do: id
+  defp song_id(%SongListen{song_id: id}), do: id
+  defp song_id({%Song{id: id}, _count}), do: id
+  defp song_id(id) when is_integer(id), do: id
+
+  defp build_upvote(song, user) do
+    SongUpvote.changeset(%SongUpvote{})
+    |> Changeset.put_assoc(:song, song)
+    |> Changeset.put_assoc(:user, user)
+  end
+
+  # Only decrements by the number of upvotes actually deleted (0 or 1), so
+  # removing a non-existent upvote does not push the count negative.
+  defp dec_upvotes_count(multi, song) do
+    Multi.run(multi, :upvotes_count, fn repo, %{song_upvote: {deleted, _}} ->
+      if deleted > 0 do
+        repo.update_all((Song |> where(id: ^song.id)), inc: [upvotes_count: -deleted])
+      end
+
+      {:ok, deleted}
+    end)
+  end
+
+  defp invalidate_charts({:ok, _} = result) do
+    Charts.invalidate_cache()
+    result
+  end
+  defp invalidate_charts(result), do: result
+end

--- a/lib/helheim_web/controllers/page_controller.ex
+++ b/lib/helheim_web/controllers/page_controller.ex
@@ -7,6 +7,7 @@ defmodule HelheimWeb.PageController do
   alias Helheim.Term
   alias Helheim.CalendarEvent
   alias Helheim.SongListen
+  alias Helheim.SongUpvoteService
   alias Helheim.Music.Charts
 
   def index(conn, _params) do
@@ -60,6 +61,17 @@ defmodule HelheimWeb.PageController do
       |> limit(5)
       |> Repo.all
 
+    top_songs_day       = Charts.top_songs_last_day(5, conn.assigns[:ignoree_ids])
+    top_songs_week      = Charts.top_songs_last_week(5, conn.assigns[:ignoree_ids])
+    top_upvoted_day     = Charts.top_upvoted_songs_last_day(5, conn.assigns[:ignoree_ids])
+    top_upvoted_week    = Charts.top_upvoted_songs_last_week(5, conn.assigns[:ignoree_ids])
+
+    upvoted_song_ids =
+      SongUpvoteService.upvoted_song_ids(
+        current_resource(conn),
+        Enum.concat([recent_song_listens, top_songs_day, top_songs_week, top_upvoted_day, top_upvoted_week])
+      )
+
     render conn, "front_page.html",
       newest_users: newest_users,
       newest_blog_posts: newest_blog_posts,
@@ -67,8 +79,11 @@ defmodule HelheimWeb.PageController do
       newest_forum_topics: newest_forum_topics,
       upcoming_events: upcoming_events,
       recent_song_listens: recent_song_listens,
-      top_songs_day: Charts.top_songs_last_day(5, conn.assigns[:ignoree_ids]),
-      top_songs_week: Charts.top_songs_last_week(5, conn.assigns[:ignoree_ids])
+      top_songs_day: top_songs_day,
+      top_songs_week: top_songs_week,
+      top_upvoted_day: top_upvoted_day,
+      top_upvoted_week: top_upvoted_week,
+      upvoted_song_ids: upvoted_song_ids
   end
 
   def terms(conn, _params) do

--- a/lib/helheim_web/controllers/profile_controller.ex
+++ b/lib/helheim_web/controllers/profile_controller.ex
@@ -69,6 +69,9 @@ defmodule HelheimWeb.ProfileController do
       |> limit(5)
       |> Repo.all
 
+    upvoted_song_ids =
+      Helheim.SongUpvoteService.upvoted_song_ids(current_resource(conn), newest_song_listens)
+
     Helheim.VisitorLogEntry.track! current_resource(conn), user
 
     render conn, "show.html",
@@ -77,7 +80,8 @@ defmodule HelheimWeb.ProfileController do
       newest_comments: newest_comments,
       newest_photos: newest_photos,
       newest_forum_topics: newest_forum_topics,
-      newest_song_listens: newest_song_listens
+      newest_song_listens: newest_song_listens,
+      upvoted_song_ids: upvoted_song_ids
   end
 
   def edit(conn, _params) do

--- a/lib/helheim_web/controllers/song_controller.ex
+++ b/lib/helheim_web/controllers/song_controller.ex
@@ -6,6 +6,7 @@ defmodule HelheimWeb.SongController do
   alias Helheim.Deezer
   alias Helheim.Song
   alias Helheim.SongListen
+  alias Helheim.SongUpvoteService
   alias Helheim.Music.Charts
 
   # The full list pages are capped at 100 pages to preserve performance.
@@ -19,24 +20,41 @@ defmodule HelheimWeb.SongController do
       |> SongListen.newest
       |> SongListen.with_preloads
       |> capped_paginate(params)
-    render(conn, "recent.html", listens: listens)
+    upvoted_song_ids = SongUpvoteService.upvoted_song_ids(current_resource(conn), listens)
+    render(conn, "recent.html", listens: listens, upvoted_song_ids: upvoted_song_ids)
   end
 
   def top_day(conn, params) do
-    render_top(conn, params, Charts.hours_ago(24), gettext("Top songs, past 24 hours"))
+    render_top(conn, params, &Song.top_by_listens_since/3, :listen_count, Charts.hours_ago(24), gettext("Top songs, past 24 hours"))
   end
 
   def top_week(conn, params) do
-    render_top(conn, params, Charts.hours_ago(24 * 7), gettext("Top songs, past 7 days"))
+    render_top(conn, params, &Song.top_by_listens_since/3, :listen_count, Charts.hours_ago(24 * 7), gettext("Top songs, past 7 days"))
   end
 
-  defp render_top(conn, params, since, title) do
+  def top_upvoted_day(conn, params) do
+    render_top(conn, params, &Song.top_by_upvotes_since/3, :upvote_count, Charts.hours_ago(24), gettext("Most upvoted songs, past 24 hours"))
+  end
+
+  def top_upvoted_week(conn, params) do
+    render_top(conn, params, &Song.top_by_upvotes_since/3, :upvote_count, Charts.hours_ago(24 * 7), gettext("Most upvoted songs, past 7 days"))
+  end
+
+  defp render_top(conn, params, chart_fun, count_key, since, title) do
     songs =
       Song
-      |> Song.top_by_listens_since(since, conn.assigns[:ignoree_ids])
+      |> chart_fun.(since, conn.assigns[:ignoree_ids])
       |> capped_paginate(params)
-    render(conn, "top.html", songs: songs, title: title)
+    render(conn, "top.html",
+      songs: songs,
+      title: title,
+      count_key: count_key,
+      empty_message: empty_message(count_key),
+      upvoted_song_ids: SongUpvoteService.upvoted_song_ids(current_resource(conn), songs))
   end
+
+  defp empty_message(:listen_count), do: gettext("No songs have been listened to in this period yet...")
+  defp empty_message(:upvote_count), do: gettext("No songs have been upvoted in this period yet...")
 
   def show(conn, %{"id" => id} = params) do
     song =
@@ -67,7 +85,40 @@ defmodule HelheimWeb.SongController do
       song: song,
       recent_listens: recent_listens,
       comments: comments,
-      current_user_has_listens: current_user_has_listens)
+      current_user_has_listens: current_user_has_listens,
+      upvoted_song_ids: SongUpvoteService.upvoted_song_ids(current_user, [song]))
+  end
+
+  def upvote(conn, %{"song_id" => song_id}) do
+    song = Repo.get!(Song, song_id)
+    ensure_vote_toggled!(SongUpvoteService.upvote!(song, current_resource(conn)))
+    vote_response(conn, song)
+  end
+
+  def remove_upvote(conn, %{"song_id" => song_id}) do
+    song = Repo.get!(Song, song_id)
+    {:ok, _} = SongUpvoteService.remove_upvote!(song, current_resource(conn))
+    vote_response(conn, song)
+  end
+
+  # A duplicate vote from a stale page is an expected no-op (the unique
+  # index rejects it and the count stays put); any other failure is a bug
+  # and should crash rather than masquerade as success.
+  defp ensure_vote_toggled!({:ok, _}), do: :ok
+  defp ensure_vote_toggled!({:error, :song_upvote, %Ecto.Changeset{}, _}), do: :ok
+
+  # Async votes (assets/js/song_upvote.js) request JSON and receive the
+  # resulting state so the page can update in place - even an expected
+  # duplicate vote returns the current state, letting a stale page resync.
+  defp vote_response(conn, song) do
+    if get_format(conn) == "json" do
+      json(conn, %{
+        upvoted: SongUpvoteService.upvoted_song_ids(current_resource(conn), [song]) != [],
+        upvotes_count: Repo.get!(Song, song.id).upvotes_count
+      })
+    else
+      redirect(conn, to: song_path(conn, :show, song))
+    end
   end
 
   # Redirects to a playable 30 second preview MP3. Deezer preview URLs

--- a/lib/helheim_web/controllers/song_listen_controller.ex
+++ b/lib/helheim_web/controllers/song_listen_controller.ex
@@ -30,7 +30,18 @@ defmodule HelheimWeb.SongListenController do
         {nil, nil}
       end
 
-    render(conn, "index.html", user: user, listens: listens, top_songs: top_songs, top_artists: top_artists)
+    upvoted_song_ids =
+      Helheim.SongUpvoteService.upvoted_song_ids(
+        current_resource(conn),
+        Enum.concat(top_songs || [], listens)
+      )
+
+    render(conn, "index.html",
+      user: user,
+      listens: listens,
+      top_songs: top_songs,
+      top_artists: top_artists,
+      upvoted_song_ids: upvoted_song_ids)
   end
 
   # Joins the aggregated {artist_name, count} rows with their enriched

--- a/lib/helheim_web/router.ex
+++ b/lib/helheim_web/router.ex
@@ -133,10 +133,14 @@ defmodule HelheimWeb.Router do
     get "/songs/recent", SongController, :recent
     get "/songs/top/day", SongController, :top_day
     get "/songs/top/week", SongController, :top_week
+    get "/songs/top/upvoted/day", SongController, :top_upvoted_day
+    get "/songs/top/upvoted/week", SongController, :top_upvoted_week
     resources "/songs", SongController, only: [:show] do
       resources "/comments", CommentController, only: [:create, :edit, :update]
       resources "/notification_subscription", NotificationSubscriptionController, singleton: true, only: [:update]
       delete "/my_listens", SongController, :remove_my_listens, as: :my_listens
+      post "/upvote", SongController, :upvote, as: :upvote
+      delete "/upvote", SongController, :remove_upvote, as: :upvote
       get "/preview", SongController, :preview, as: :preview
     end
   end

--- a/lib/helheim_web/templates/page/front_page.html.eex
+++ b/lib/helheim_web/templates/page/front_page.html.eex
@@ -85,40 +85,46 @@
           <%= link gettext("Show All"), to: song_path(@conn, :recent), class: "btn btn-outline-primary btn-sm mb-0" %>
         </h5>
         <%= for listen <- @recent_song_listens do %>
-          <%= render HelheimWeb.SongView, "_listen.html", conn: @conn, listen: listen %>
+          <%= render HelheimWeb.SongView, "_listen.html", conn: @conn, listen: listen, upvoted_song_ids: @upvoted_song_ids %>
         <% end %>
       </div>
     </div>
 
-    <div class="card">
-      <div class="card-block">
-        <h5 class="mb-1 d-flex justify-content-between">
-          <%= gettext "Top songs, past 24 hours" %>
-          <%= link gettext("Show All"), to: song_path(@conn, :top_day), class: "btn btn-outline-primary btn-sm mb-0" %>
-        </h5>
-        <%= if length(@top_songs_day) == 0 do %>
-          <p class="text-muted"><%= gettext "No songs have been listened to in this period yet..." %></p>
-        <% end %>
-        <%= for {song, count} <- @top_songs_day do %>
-          <%= render HelheimWeb.SongView, "_song.html", conn: @conn, song: song, listen_count: count %>
-        <% end %>
-      </div>
-    </div>
+    <%= render HelheimWeb.SongView, "_chart_card.html", conn: @conn,
+          title: gettext("Top songs, past 24 hours"),
+          show_all_path: song_path(@conn, :top_day),
+          songs: @top_songs_day,
+          count_key: :listen_count,
+          empty_message: gettext("No songs have been listened to in this period yet..."),
+          upvoted_song_ids: @upvoted_song_ids %>
 
-    <div class="card">
-      <div class="card-block">
-        <h5 class="mb-1 d-flex justify-content-between">
-          <%= gettext "Top songs, past 7 days" %>
-          <%= link gettext("Show All"), to: song_path(@conn, :top_week), class: "btn btn-outline-primary btn-sm mb-0" %>
-        </h5>
-        <%= if length(@top_songs_week) == 0 do %>
-          <p class="text-muted"><%= gettext "No songs have been listened to in this period yet..." %></p>
-        <% end %>
-        <%= for {song, count} <- @top_songs_week do %>
-          <%= render HelheimWeb.SongView, "_song.html", conn: @conn, song: song, listen_count: count %>
-        <% end %>
-      </div>
-    </div>
+    <%= render HelheimWeb.SongView, "_chart_card.html", conn: @conn,
+          title: gettext("Top songs, past 7 days"),
+          show_all_path: song_path(@conn, :top_week),
+          songs: @top_songs_week,
+          count_key: :listen_count,
+          empty_message: gettext("No songs have been listened to in this period yet..."),
+          upvoted_song_ids: @upvoted_song_ids %>
+  </div>
+<% end %>
+
+<%= if length(@top_upvoted_day) + length(@top_upvoted_week) > 0 do %>
+  <div class="card-group mt-1">
+    <%= render HelheimWeb.SongView, "_chart_card.html", conn: @conn,
+          title: gettext("Most upvoted songs, past 24 hours"),
+          show_all_path: song_path(@conn, :top_upvoted_day),
+          songs: @top_upvoted_day,
+          count_key: :upvote_count,
+          empty_message: gettext("No songs have been upvoted in this period yet..."),
+          upvoted_song_ids: @upvoted_song_ids %>
+
+    <%= render HelheimWeb.SongView, "_chart_card.html", conn: @conn,
+          title: gettext("Most upvoted songs, past 7 days"),
+          show_all_path: song_path(@conn, :top_upvoted_week),
+          songs: @top_upvoted_week,
+          count_key: :upvote_count,
+          empty_message: gettext("No songs have been upvoted in this period yet..."),
+          upvoted_song_ids: @upvoted_song_ids %>
   </div>
 <% end %>
 

--- a/lib/helheim_web/templates/profile/show.html.eex
+++ b/lib/helheim_web/templates/profile/show.html.eex
@@ -99,7 +99,7 @@
     <div class="card-block">
       <h5 class="mb-1"><%= gettext "Latest listens" %></h5>
       <%= for listen <- @newest_song_listens do %>
-        <%= render HelheimWeb.SongView, "_song.html", conn: @conn, song: listen.song %>
+        <%= render HelheimWeb.SongView, "_song.html", conn: @conn, song: listen.song, upvoted_song_ids: @upvoted_song_ids %>
       <% end %>
       <%= link gettext("Show All"), to: public_profile_music_path(@conn, :index, @user), class: "btn btn-outline-secondary btn-block mb-0" %>
     </div>

--- a/lib/helheim_web/templates/song/_chart_card.html.eex
+++ b/lib/helheim_web/templates/song/_chart_card.html.eex
@@ -1,0 +1,14 @@
+<div class="card">
+  <div class="card-block">
+    <h5 class="mb-1 d-flex justify-content-between">
+      <%= @title %>
+      <%= link gettext("Show All"), to: @show_all_path, class: "btn btn-outline-primary btn-sm mb-0" %>
+    </h5>
+    <%= if length(@songs) == 0 do %>
+      <p class="text-muted"><%= @empty_message %></p>
+    <% end %>
+    <%= for {song, count} <- @songs do %>
+      <%= render "_song.html", [{@count_key, count}, conn: @conn, song: song, upvoted_song_ids: @upvoted_song_ids] %>
+    <% end %>
+  </div>
+</div>

--- a/lib/helheim_web/templates/song/_listen.html.eex
+++ b/lib/helheim_web/templates/song/_listen.html.eex
@@ -16,5 +16,6 @@
     </small>
     <br>
     <%= comment_count_badge @listen.song %>
+    <%= upvote_toggle @conn, @listen.song, assigns %>
   </div>
 </div>

--- a/lib/helheim_web/templates/song/_song.html.eex
+++ b/lib/helheim_web/templates/song/_song.html.eex
@@ -12,5 +12,9 @@
     <%= if assigns[:listen_count] do %>
       <%= listen_count_badge @listen_count %>
     <% end %>
+    <%= if assigns[:upvote_count] do %>
+      <%= upvote_count_badge @upvote_count %>
+    <% end %>
+    <%= upvote_toggle @conn, @song, assigns %>
   </div>
 </div>

--- a/lib/helheim_web/templates/song/recent.html.eex
+++ b/lib/helheim_web/templates/song/recent.html.eex
@@ -6,7 +6,7 @@
       <p class="text-muted mb-0"><%= gettext "No listens have been tracked yet..." %></p>
     <% end %>
     <%= for listen <- @listens do %>
-      <%= render "_listen.html", conn: @conn, listen: listen %>
+      <%= render "_listen.html", conn: @conn, listen: listen, upvoted_song_ids: @upvoted_song_ids %>
     <% end %>
     <%= pagination_links @conn, @listens %>
   </div>

--- a/lib/helheim_web/templates/song/show.html.eex
+++ b/lib/helheim_web/templates/song/show.html.eex
@@ -36,6 +36,10 @@
             <th><%= gettext "Listens" %></th>
             <td><%= @song.listens_count %></td>
           </tr>
+          <tr>
+            <th><%= gettext "Upvotes" %></th>
+            <td><%= upvote_toggle @conn, @song, assigns %></td>
+          </tr>
         </table>
         <%= if length(@song.song_tags) > 0 do %>
           <p>

--- a/lib/helheim_web/templates/song/top.html.eex
+++ b/lib/helheim_web/templates/song/top.html.eex
@@ -3,10 +3,10 @@
 <div class="card">
   <div class="card-block">
     <%= if Enum.empty?(@songs) do %>
-      <p class="text-muted mb-0"><%= gettext "No songs have been listened to in this period yet..." %></p>
+      <p class="text-muted mb-0"><%= @empty_message %></p>
     <% end %>
     <%= for {song, count} <- @songs do %>
-      <%= render "_song.html", conn: @conn, song: song, listen_count: count %>
+      <%= render "_song.html", [{@count_key, count}, conn: @conn, song: song, upvoted_song_ids: @upvoted_song_ids] %>
     <% end %>
     <%= pagination_links @conn, @songs %>
   </div>

--- a/lib/helheim_web/templates/song_listen/index.html.eex
+++ b/lib/helheim_web/templates/song_listen/index.html.eex
@@ -9,7 +9,7 @@
           <p class="text-muted mb-0"><%= gettext "No listens have been tracked yet..." %></p>
         <% end %>
         <%= for {song, count} <- @top_songs do %>
-          <%= render HelheimWeb.SongView, "_song.html", conn: @conn, song: song, listen_count: count %>
+          <%= render HelheimWeb.SongView, "_song.html", conn: @conn, song: song, listen_count: count, upvoted_song_ids: @upvoted_song_ids %>
         <% end %>
       </div>
     </div>
@@ -49,7 +49,7 @@
       <p class="text-muted mb-0"><%= gettext "No listens have been tracked yet..." %></p>
     <% end %>
     <%= for listen <- @listens do %>
-      <%= render HelheimWeb.SongView, "_listen.html", conn: @conn, listen: listen, show_username: false %>
+      <%= render HelheimWeb.SongView, "_listen.html", conn: @conn, listen: listen, show_username: false, upvoted_song_ids: @upvoted_song_ids %>
     <% end %>
     <%= pagination_links @conn, @listens %>
   </div>

--- a/lib/helheim_web/views/song_view.ex
+++ b/lib/helheim_web/views/song_view.ex
@@ -53,6 +53,60 @@ defmodule HelheimWeb.SongView do
     end
   end
 
+  @doc """
+  The hand-horns icon used for upvotes. Font Awesome's free set has no
+  hand-horns glyph, so this is an inline SVG (Boxicons "hand rock", MIT),
+  sized via `.icon-horns` to line up with the fixed-width font icons.
+  """
+  def horns_icon do
+    {:safe,
+     ~s(<svg class="icon-horns" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M19.5 5A2.5 2.5 0 0 0 17 7.5v.55c-.16-.03-.33-.05-.5-.05c-.56 0-1.08.2-1.5.51a2.47 2.47 0 0 0-2-.46V5.5a2.5 2.5 0 0 0-5 0v7.66l-1.61-1.05a2.39 2.39 0 0 0-3.69 1.88c-.04.68.22 1.34.7 1.82l3.73 3.73c.94.94 2.2 1.46 3.54 1.46h6.34c2.76 0 5-2.24 5-5V7.5a2.5 2.5 0 0 0-2.5-2.5ZM16 10.5c0-.28.22-.5.5-.5s.5.22.5.5v2c0 .28-.22.5-.5.5s-.5-.22-.5-.5zm-3 .5v-.5c0-.28.22-.5.5-.5s.5.22.5.5v3c0 .28-.22.5-.5.5s-.5-.22-.5-.5zm7 5c0 1.65-1.35 3-3 3h-6.34c-.79 0-1.56-.32-2.12-.88l-3.73-3.73a.35.35 0 0 1-.11-.3c0-.07.03-.19.15-.29a.39.39 0 0 1 .46-.02l3.16 2.05c.31.2.7.21 1.02.04s.52-.51.52-.88V5.5c0-.28.22-.5.5-.5s.5.22.5.5v8a2.5 2.5 0 0 0 2.5 2.5c.89 0 1.67-.47 2.11-1.17c.28.11.58.17.89.17a2.5 2.5 0 0 0 2.5-2.5v-5c0-.28.22-.5.5-.5s.5.22.5.5V16Z"/></svg>)}
+  end
+
+  @doc """
+  The song's upvote count during a chart's window, as a plain badge. The
+  interactive upvote toggle always shows the all-time total, so the two
+  numbers can sit side by side on chart rows without disagreeing about
+  what they mean.
+  """
+  def upvote_count_badge(count) do
+    content_tag :span, class: "badge badge-default" do
+      [content_tag(:i, "", class: "fa fa-fw fa-fire"), {:safe, [" #{count}"]}]
+    end
+  end
+
+  @doc """
+  A badge-styled toggle that upvotes the song - or removes the viewer's
+  upvote if they already cast one - showing only the hand-horns icon and
+  the song's all-time upvote count, matching the look of the comment and
+  listen count badges. The button state comes from the required
+  `upvoted_song_ids` assign (the ids the viewer has upvoted among the
+  songs on the page - required so a page that forgets to compute it fails
+  loudly instead of rendering every button un-upvoted). Voting happens
+  asynchronously via assets/js/song_upvote.js, which snaps every badge
+  for the song to the state and count the server returns.
+  """
+  def upvote_toggle(conn, song, assigns) do
+    upvoted = song.id in Map.fetch!(assigns, :upvoted_song_ids)
+    upvote_label = gettext("Upvote")
+    remove_label = gettext("Remove your upvote")
+    {badge, title} = if upvoted, do: {"badge-primary", remove_label}, else: {"badge-default", upvote_label}
+
+    content_tag(:button, [horns_icon(), {:safe, " "}, content_tag(:span, "#{song.upvotes_count}", class: "song-upvote-count")],
+      type: "button",
+      class: "badge #{badge} song-upvote-button",
+      title: title,
+      aria_label: title,
+      aria_pressed: "#{upvoted}",
+      data: [
+        song_id: song.id,
+        upvoted: "#{upvoted}",
+        upvote_url: song_upvote_path(conn, :upvote, song),
+        title_upvote: upvote_label,
+        title_remove: remove_label
+      ])
+  end
+
   def lastfm_link(nil, _label), do: nil
   def lastfm_link(url, label) do
     link to: url, target: "_blank", rel: "noopener" do

--- a/priv/gettext/da/LC_MESSAGES/default.po
+++ b/priv/gettext/da/LC_MESSAGES/default.po
@@ -425,7 +425,7 @@ msgstr "Personlige detaljer"
 msgid "Update Account"
 msgstr "Opdatér Konto"
 
-#: lib/helheim/models/user.ex:372
+#: lib/helheim/models/user.ex:380
 #, elixir-autogen
 msgid "does not match your current password"
 msgstr "matcher ikke dit nuværende kodeord"
@@ -458,7 +458,7 @@ msgstr "Profil Indstillinger"
 msgid "Profile Text"
 msgstr "Profiltekst"
 
-#: lib/helheim_web/controllers/profile_controller.ex:95
+#: lib/helheim_web/controllers/profile_controller.ex:99
 #, elixir-autogen
 msgid "Profile updated!"
 msgstr "Din profil blev opdateret!"
@@ -485,7 +485,7 @@ msgstr "Nyeste Blogs"
 msgid "Newest Forum Posts"
 msgstr "Nyeste Forumindlæg"
 
-#: lib/helheim_web/templates/page/front_page.html.eex:129
+#: lib/helheim_web/templates/page/front_page.html.eex:135
 #: lib/helheim_web/templates/profile/show.html.eex:111
 #, elixir-autogen
 msgid "Newest Photos"
@@ -614,12 +614,11 @@ msgstr "Tilføj Kommentar"
 #: lib/helheim_web/templates/page/front_page.html.eex:41
 #: lib/helheim_web/templates/page/front_page.html.eex:56
 #: lib/helheim_web/templates/page/front_page.html.eex:85
-#: lib/helheim_web/templates/page/front_page.html.eex:97
-#: lib/helheim_web/templates/page/front_page.html.eex:112
-#: lib/helheim_web/templates/page/front_page.html.eex:130
+#: lib/helheim_web/templates/page/front_page.html.eex:136
 #: lib/helheim_web/templates/profile/show.html.eex:81
 #: lib/helheim_web/templates/profile/show.html.eex:104
 #: lib/helheim_web/templates/profile/show.html.eex:117
+#: lib/helheim_web/templates/song/_chart_card.html.eex:5
 #, elixir-autogen
 msgid "Show All"
 msgstr "Vis alle"
@@ -1836,7 +1835,7 @@ msgstr "Vi har modtaget din donation og takker ydmygt for din hjælp med at gør
 msgid "Edited"
 msgstr "Redigeret"
 
-#: lib/helheim/models/user.ex:405
+#: lib/helheim/models/user.ex:413
 #, elixir-autogen
 msgid "I too enjoy registering on websites, fellow human... Bleep Bloop!"
 msgstr "I too enjoy registering on websites, fellow human… Bleep Bloop!"
@@ -2746,12 +2745,12 @@ msgstr "Musik fra %{username}"
 msgid "No listens have been tracked yet..."
 msgstr "Der er ikke registreret nogen afspilninger endnu..."
 
-#: lib/helheim_web/templates/song/show.html.eex:73
+#: lib/helheim_web/templates/song/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "No one has listened to this song yet..."
 msgstr "Ingen har lyttet til denne sang endnu..."
 
-#: lib/helheim_web/templates/song/show.html.eex:71
+#: lib/helheim_web/templates/song/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Recent listeners"
 msgstr "Seneste lyttere"
@@ -2787,27 +2786,27 @@ msgstr "Du kan også slette hele din lyttehistorik fra siden. Dette kan ikke for
 msgid "Your listening history has been deleted."
 msgstr "Din lyttehistorik er blevet slettet."
 
-#: lib/helheim_web/templates/song/show.html.eex:58
+#: lib/helheim_web/templates/song/show.html.eex:62
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Your listens of this song will be permanently removed!"
 msgstr "Er du sikker? Dine afspilninger af denne sang bliver fjernet permanent!"
 
-#: lib/helheim_web/templates/song/show.html.eex:60
+#: lib/helheim_web/templates/song/show.html.eex:64
 #, elixir-autogen, elixir-format
 msgid "Remove my name from this song"
 msgstr "Fjern mit navn fra denne sang"
 
-#: lib/helheim_web/controllers/song_controller.ex:104
+#: lib/helheim_web/controllers/song_controller.ex:162
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr "Dine afspilninger er blevet fjernet fra denne sang."
 
-#: lib/helheim_web/templates/song/show.html.eex:52
+#: lib/helheim_web/templates/song/show.html.eex:56
 #, elixir-autogen, elixir-format
 msgid "Album on Last.fm"
 msgstr "Album på Last.fm"
 
-#: lib/helheim_web/templates/song/show.html.eex:49
+#: lib/helheim_web/templates/song/show.html.eex:53
 #, elixir-autogen, elixir-format
 msgid "Artist on Last.fm"
 msgstr "Kunstner på Last.fm"
@@ -2853,7 +2852,7 @@ msgstr "Forbind Last.fm igen"
 msgid "Set up scrobbling on Last.fm"
 msgstr "Opsæt scrobbling på Last.fm"
 
-#: lib/helheim_web/templates/song/show.html.eex:48
+#: lib/helheim_web/templates/song/show.html.eex:52
 #, elixir-autogen, elixir-format
 msgid "Song on Last.fm"
 msgstr "Sang på Last.fm"
@@ -2884,21 +2883,21 @@ msgstr "Din Last.fm-konto er blevet afbrudt."
 msgid "Your Last.fm account is now connected!"
 msgstr "Din Last.fm-konto er nu forbundet!"
 
-#: lib/helheim_web/templates/page/front_page.html.eex:100
-#: lib/helheim_web/templates/page/front_page.html.eex:115
-#: lib/helheim_web/templates/song/top.html.eex:6
+#: lib/helheim_web/controllers/song_controller.ex:56
+#: lib/helheim_web/templates/page/front_page.html.eex:98
+#: lib/helheim_web/templates/page/front_page.html.eex:106
 #, elixir-autogen, elixir-format
 msgid "No songs have been listened to in this period yet..."
 msgstr "Der er ikke lyttet til nogen sange i denne periode endnu..."
 
-#: lib/helheim_web/controllers/song_controller.ex:26
-#: lib/helheim_web/templates/page/front_page.html.eex:96
+#: lib/helheim_web/controllers/song_controller.ex:28
+#: lib/helheim_web/templates/page/front_page.html.eex:94
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 24 hours"
 msgstr "Top sange, seneste 24 timer"
 
-#: lib/helheim_web/controllers/song_controller.ex:30
-#: lib/helheim_web/templates/page/front_page.html.eex:111
+#: lib/helheim_web/controllers/song_controller.ex:32
+#: lib/helheim_web/templates/page/front_page.html.eex:102
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 7 days"
 msgstr "Top sange, seneste 7 dage"
@@ -2919,3 +2918,37 @@ msgstr "Årstal"
 #, elixir-autogen, elixir-format
 msgid "Play preview"
 msgstr "Hør smagsprøve"
+
+#: lib/helheim_web/controllers/song_controller.ex:36
+#: lib/helheim_web/templates/page/front_page.html.eex:114
+#, elixir-autogen, elixir-format
+msgid "Most upvoted songs, past 24 hours"
+msgstr "Mest likede sange, seneste 24 timer"
+
+#: lib/helheim_web/controllers/song_controller.ex:40
+#: lib/helheim_web/templates/page/front_page.html.eex:122
+#, elixir-autogen, elixir-format
+msgid "Most upvoted songs, past 7 days"
+msgstr "Mest likede sange, seneste 7 dage"
+
+#: lib/helheim_web/controllers/song_controller.ex:57
+#: lib/helheim_web/templates/page/front_page.html.eex:118
+#: lib/helheim_web/templates/page/front_page.html.eex:126
+#, elixir-autogen, elixir-format
+msgid "No songs have been upvoted in this period yet..."
+msgstr "Ingen sange har fået likes i denne periode endnu..."
+
+#: lib/helheim_web/views/song_view.ex:91
+#, elixir-autogen, elixir-format
+msgid "Upvote"
+msgstr "Like"
+
+#: lib/helheim_web/templates/song/show.html.eex:40
+#, elixir-autogen, elixir-format
+msgid "Upvotes"
+msgstr "Likes"
+
+#: lib/helheim_web/views/song_view.ex:92
+#, elixir-autogen, elixir-format
+msgid "Remove your upvote"
+msgstr "Fjern like"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -414,7 +414,7 @@ msgstr ""
 msgid "Update Account"
 msgstr ""
 
-#: lib/helheim/models/user.ex:372
+#: lib/helheim/models/user.ex:380
 #, elixir-autogen
 msgid "does not match your current password"
 msgstr ""
@@ -447,7 +447,7 @@ msgstr ""
 msgid "Profile Text"
 msgstr ""
 
-#: lib/helheim_web/controllers/profile_controller.ex:95
+#: lib/helheim_web/controllers/profile_controller.ex:99
 #, elixir-autogen
 msgid "Profile updated!"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "Newest Forum Posts"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:129
+#: lib/helheim_web/templates/page/front_page.html.eex:135
 #: lib/helheim_web/templates/profile/show.html.eex:111
 #, elixir-autogen
 msgid "Newest Photos"
@@ -603,12 +603,11 @@ msgstr ""
 #: lib/helheim_web/templates/page/front_page.html.eex:41
 #: lib/helheim_web/templates/page/front_page.html.eex:56
 #: lib/helheim_web/templates/page/front_page.html.eex:85
-#: lib/helheim_web/templates/page/front_page.html.eex:97
-#: lib/helheim_web/templates/page/front_page.html.eex:112
-#: lib/helheim_web/templates/page/front_page.html.eex:130
+#: lib/helheim_web/templates/page/front_page.html.eex:136
 #: lib/helheim_web/templates/profile/show.html.eex:81
 #: lib/helheim_web/templates/profile/show.html.eex:104
 #: lib/helheim_web/templates/profile/show.html.eex:117
+#: lib/helheim_web/templates/song/_chart_card.html.eex:5
 #, elixir-autogen
 msgid "Show All"
 msgstr ""
@@ -1825,7 +1824,7 @@ msgstr ""
 msgid "Edited"
 msgstr ""
 
-#: lib/helheim/models/user.ex:405
+#: lib/helheim/models/user.ex:413
 #, elixir-autogen
 msgid "I too enjoy registering on websites, fellow human... Bleep Bloop!"
 msgstr ""
@@ -2735,12 +2734,12 @@ msgstr ""
 msgid "No listens have been tracked yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:73
+#: lib/helheim_web/templates/song/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "No one has listened to this song yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:71
+#: lib/helheim_web/templates/song/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Recent listeners"
 msgstr ""
@@ -2776,27 +2775,27 @@ msgstr ""
 msgid "Your listening history has been deleted."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:58
+#: lib/helheim_web/templates/song/show.html.eex:62
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Your listens of this song will be permanently removed!"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:60
+#: lib/helheim_web/templates/song/show.html.eex:64
 #, elixir-autogen, elixir-format
 msgid "Remove my name from this song"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:104
+#: lib/helheim_web/controllers/song_controller.ex:162
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:52
+#: lib/helheim_web/templates/song/show.html.eex:56
 #, elixir-autogen, elixir-format
 msgid "Album on Last.fm"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:49
+#: lib/helheim_web/templates/song/show.html.eex:53
 #, elixir-autogen, elixir-format
 msgid "Artist on Last.fm"
 msgstr ""
@@ -2842,7 +2841,7 @@ msgstr ""
 msgid "Set up scrobbling on Last.fm"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:48
+#: lib/helheim_web/templates/song/show.html.eex:52
 #, elixir-autogen, elixir-format
 msgid "Song on Last.fm"
 msgstr ""
@@ -2873,21 +2872,21 @@ msgstr ""
 msgid "Your Last.fm account is now connected!"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:100
-#: lib/helheim_web/templates/page/front_page.html.eex:115
-#: lib/helheim_web/templates/song/top.html.eex:6
+#: lib/helheim_web/controllers/song_controller.ex:56
+#: lib/helheim_web/templates/page/front_page.html.eex:98
+#: lib/helheim_web/templates/page/front_page.html.eex:106
 #, elixir-autogen, elixir-format
 msgid "No songs have been listened to in this period yet..."
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:26
-#: lib/helheim_web/templates/page/front_page.html.eex:96
+#: lib/helheim_web/controllers/song_controller.ex:28
+#: lib/helheim_web/templates/page/front_page.html.eex:94
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 24 hours"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:30
-#: lib/helheim_web/templates/page/front_page.html.eex:111
+#: lib/helheim_web/controllers/song_controller.ex:32
+#: lib/helheim_web/templates/page/front_page.html.eex:102
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 7 days"
 msgstr ""
@@ -2907,4 +2906,38 @@ msgstr ""
 #: lib/helheim_web/views/song_view.ex:45
 #, elixir-autogen, elixir-format
 msgid "Play preview"
+msgstr ""
+
+#: lib/helheim_web/controllers/song_controller.ex:36
+#: lib/helheim_web/templates/page/front_page.html.eex:114
+#, elixir-autogen, elixir-format
+msgid "Most upvoted songs, past 24 hours"
+msgstr ""
+
+#: lib/helheim_web/controllers/song_controller.ex:40
+#: lib/helheim_web/templates/page/front_page.html.eex:122
+#, elixir-autogen, elixir-format
+msgid "Most upvoted songs, past 7 days"
+msgstr ""
+
+#: lib/helheim_web/controllers/song_controller.ex:57
+#: lib/helheim_web/templates/page/front_page.html.eex:118
+#: lib/helheim_web/templates/page/front_page.html.eex:126
+#, elixir-autogen, elixir-format
+msgid "No songs have been upvoted in this period yet..."
+msgstr ""
+
+#: lib/helheim_web/views/song_view.ex:91
+#, elixir-autogen, elixir-format
+msgid "Upvote"
+msgstr ""
+
+#: lib/helheim_web/templates/song/show.html.eex:40
+#, elixir-autogen, elixir-format
+msgid "Upvotes"
+msgstr ""
+
+#: lib/helheim_web/views/song_view.ex:92
+#, elixir-autogen, elixir-format
+msgid "Remove your upvote"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -414,7 +414,7 @@ msgstr ""
 msgid "Update Account"
 msgstr ""
 
-#: lib/helheim/models/user.ex:372
+#: lib/helheim/models/user.ex:380
 #, elixir-autogen
 msgid "does not match your current password"
 msgstr ""
@@ -447,7 +447,7 @@ msgstr ""
 msgid "Profile Text"
 msgstr ""
 
-#: lib/helheim_web/controllers/profile_controller.ex:95
+#: lib/helheim_web/controllers/profile_controller.ex:99
 #, elixir-autogen
 msgid "Profile updated!"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "Newest Forum Posts"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:129
+#: lib/helheim_web/templates/page/front_page.html.eex:135
 #: lib/helheim_web/templates/profile/show.html.eex:111
 #, elixir-autogen
 msgid "Newest Photos"
@@ -603,12 +603,11 @@ msgstr ""
 #: lib/helheim_web/templates/page/front_page.html.eex:41
 #: lib/helheim_web/templates/page/front_page.html.eex:56
 #: lib/helheim_web/templates/page/front_page.html.eex:85
-#: lib/helheim_web/templates/page/front_page.html.eex:97
-#: lib/helheim_web/templates/page/front_page.html.eex:112
-#: lib/helheim_web/templates/page/front_page.html.eex:130
+#: lib/helheim_web/templates/page/front_page.html.eex:136
 #: lib/helheim_web/templates/profile/show.html.eex:81
 #: lib/helheim_web/templates/profile/show.html.eex:104
 #: lib/helheim_web/templates/profile/show.html.eex:117
+#: lib/helheim_web/templates/song/_chart_card.html.eex:5
 #, elixir-autogen
 msgid "Show All"
 msgstr ""
@@ -1825,7 +1824,7 @@ msgstr ""
 msgid "Edited"
 msgstr ""
 
-#: lib/helheim/models/user.ex:405
+#: lib/helheim/models/user.ex:413
 #, elixir-autogen
 msgid "I too enjoy registering on websites, fellow human... Bleep Bloop!"
 msgstr ""
@@ -2735,12 +2734,12 @@ msgstr ""
 msgid "No listens have been tracked yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:73
+#: lib/helheim_web/templates/song/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "No one has listened to this song yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:71
+#: lib/helheim_web/templates/song/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Recent listeners"
 msgstr ""
@@ -2776,27 +2775,27 @@ msgstr ""
 msgid "Your listening history has been deleted."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:58
+#: lib/helheim_web/templates/song/show.html.eex:62
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure? Your listens of this song will be permanently removed!"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:60
+#: lib/helheim_web/templates/song/show.html.eex:64
 #, elixir-autogen, elixir-format
 msgid "Remove my name from this song"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:104
+#: lib/helheim_web/controllers/song_controller.ex:162
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:52
+#: lib/helheim_web/templates/song/show.html.eex:56
 #, elixir-autogen, elixir-format
 msgid "Album on Last.fm"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:49
+#: lib/helheim_web/templates/song/show.html.eex:53
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Artist on Last.fm"
 msgstr ""
@@ -2842,7 +2841,7 @@ msgstr ""
 msgid "Set up scrobbling on Last.fm"
 msgstr ""
 
-#: lib/helheim_web/templates/song/show.html.eex:48
+#: lib/helheim_web/templates/song/show.html.eex:52
 #, elixir-autogen, elixir-format
 msgid "Song on Last.fm"
 msgstr ""
@@ -2873,21 +2872,21 @@ msgstr ""
 msgid "Your Last.fm account is now connected!"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:100
-#: lib/helheim_web/templates/page/front_page.html.eex:115
-#: lib/helheim_web/templates/song/top.html.eex:6
+#: lib/helheim_web/controllers/song_controller.ex:56
+#: lib/helheim_web/templates/page/front_page.html.eex:98
+#: lib/helheim_web/templates/page/front_page.html.eex:106
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No songs have been listened to in this period yet..."
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:26
-#: lib/helheim_web/templates/page/front_page.html.eex:96
+#: lib/helheim_web/controllers/song_controller.ex:28
+#: lib/helheim_web/templates/page/front_page.html.eex:94
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 24 hours"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:30
-#: lib/helheim_web/templates/page/front_page.html.eex:111
+#: lib/helheim_web/controllers/song_controller.ex:32
+#: lib/helheim_web/templates/page/front_page.html.eex:102
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Top songs, past 7 days"
 msgstr ""
@@ -2907,4 +2906,38 @@ msgstr ""
 #: lib/helheim_web/views/song_view.ex:45
 #, elixir-autogen, elixir-format
 msgid "Play preview"
+msgstr ""
+
+#: lib/helheim_web/controllers/song_controller.ex:36
+#: lib/helheim_web/templates/page/front_page.html.eex:114
+#, elixir-autogen, elixir-format
+msgid "Most upvoted songs, past 24 hours"
+msgstr ""
+
+#: lib/helheim_web/controllers/song_controller.ex:40
+#: lib/helheim_web/templates/page/front_page.html.eex:122
+#, elixir-autogen, elixir-format
+msgid "Most upvoted songs, past 7 days"
+msgstr ""
+
+#: lib/helheim_web/controllers/song_controller.ex:57
+#: lib/helheim_web/templates/page/front_page.html.eex:118
+#: lib/helheim_web/templates/page/front_page.html.eex:126
+#, elixir-autogen, elixir-format
+msgid "No songs have been upvoted in this period yet..."
+msgstr ""
+
+#: lib/helheim_web/views/song_view.ex:91
+#, elixir-autogen, elixir-format
+msgid "Upvote"
+msgstr ""
+
+#: lib/helheim_web/templates/song/show.html.eex:40
+#, elixir-autogen, elixir-format
+msgid "Upvotes"
+msgstr ""
+
+#: lib/helheim_web/views/song_view.ex:92
+#, elixir-autogen, elixir-format
+msgid "Remove your upvote"
 msgstr ""

--- a/priv/repo/migrations/20260722000001_create_song_upvotes.exs
+++ b/priv/repo/migrations/20260722000001_create_song_upvotes.exs
@@ -1,0 +1,22 @@
+defmodule Helheim.Repo.Migrations.CreateSongUpvotes do
+  use Ecto.Migration
+
+  def change do
+    create table(:song_upvotes) do
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :song_id, references(:songs, on_delete: :delete_all), null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:song_upvotes, [:user_id, :song_id])
+    create index(:song_upvotes, [:song_id])
+    # Serves the rolling-window charts, which filter on inserted_at and then
+    # group by song; leading with inserted_at keeps the range scan tight and
+    # including song_id lets it satisfy the join without heap fetches.
+    create index(:song_upvotes, [:inserted_at, :song_id])
+
+    alter table(:songs) do
+      add :upvotes_count, :integer, null: false, default: 0
+    end
+  end
+end

--- a/test/helheim/music/charts_test.exs
+++ b/test/helheim/music/charts_test.exs
@@ -65,4 +65,68 @@ defmodule Helheim.Music.ChartsTest do
       assert top_song.id == song.id
     end
   end
+
+  describe "top_upvoted_songs_since/2" do
+    test "orders songs by number of upvotes since the given time and excludes older upvotes" do
+      since = Timex.shift(Timex.now, days: -1)
+      song_1 = insert(:song)
+      song_2 = insert(:song)
+      song_3 = insert(:song)
+      insert(:song_upvote, song: song_1)
+      insert_list(2, :song_upvote, song: song_2)
+      insert(:song_upvote, song: song_3, inserted_at: Timex.shift(Timex.now, days: -2))
+
+      results = Charts.top_upvoted_songs_since(since, 10)
+
+      assert [{top_song, 2}, {runner_up, 1}] = results
+      assert top_song.id == song_2.id
+      assert runner_up.id == song_1.id
+    end
+
+    test "limits the number of results" do
+      insert_list(3, :song_upvote)
+      assert length(Charts.top_upvoted_songs_since(Timex.shift(Timex.now, days: -1), 2)) == 2
+    end
+
+    test "excludes upvotes from the given user ids" do
+      since = Timex.shift(Timex.now, days: -1)
+      ignoree = insert(:user)
+      song = insert(:song)
+      insert(:song_upvote, user: ignoree, song: song)
+      other_upvote = insert(:song_upvote)
+
+      results = Charts.top_upvoted_songs_since(since, 10, [ignoree.id])
+
+      assert [{top_song, 1}] = results
+      assert top_song.id == other_upvote.song_id
+    end
+  end
+
+  describe "top_upvoted_songs_last_day/2" do
+    test "includes upvotes from the past 24 hours and excludes older ones" do
+      song = insert(:song)
+      insert(:song_upvote, song: song, inserted_at: Timex.shift(Timex.now, hours: -23))
+      old_song = insert(:song)
+      insert(:song_upvote, song: old_song, inserted_at: Timex.shift(Timex.now, hours: -25))
+
+      results = Charts.top_upvoted_songs_last_day(10)
+
+      assert [{top_song, 1}] = results
+      assert top_song.id == song.id
+    end
+  end
+
+  describe "top_upvoted_songs_last_week/2" do
+    test "includes upvotes from the past 7 days and excludes older ones" do
+      song = insert(:song)
+      insert(:song_upvote, song: song, inserted_at: Timex.shift(Timex.now, days: -6))
+      old_song = insert(:song)
+      insert(:song_upvote, song: old_song, inserted_at: Timex.shift(Timex.now, days: -8))
+
+      results = Charts.top_upvoted_songs_last_week(10)
+
+      assert [{top_song, 1}] = results
+      assert top_song.id == song.id
+    end
+  end
 end

--- a/test/helheim/services/song_upvote_service_test.exs
+++ b/test/helheim/services/song_upvote_service_test.exs
@@ -1,0 +1,134 @@
+defmodule Helheim.SongUpvoteServiceTest do
+  use Helheim.DataCase
+  alias Helheim.SongUpvoteService
+  alias Helheim.SongUpvote
+  alias Helheim.Song
+
+  ##############################################################################
+  # upvote!/2
+  describe "upvote!/2" do
+    test "creates an upvote from the user on the song" do
+      user = insert(:user)
+      song = insert(:song)
+
+      {:ok, %{song_upvote: upvote}} = SongUpvoteService.upvote!(song, user)
+
+      assert upvote.user_id == user.id
+      assert upvote.song_id == song.id
+    end
+
+    test "increments the upvotes_count of the song" do
+      user = insert(:user)
+      song = insert(:song, upvotes_count: 0)
+
+      SongUpvoteService.upvote!(song, user)
+
+      assert Repo.get(Song, song.id).upvotes_count == 1
+    end
+
+    test "does not create a second upvote or double increment when the user already upvoted" do
+      user = insert(:user)
+      song = insert(:song, upvotes_count: 0)
+
+      {:ok, _} = SongUpvoteService.upvote!(song, user)
+      {:error, :song_upvote, _changeset, _changes} = SongUpvoteService.upvote!(song, user)
+
+      assert Repo.aggregate(SongUpvote, :count) == 1
+      assert Repo.get(Song, song.id).upvotes_count == 1
+    end
+
+    test "lets different users each upvote the same song" do
+      song = insert(:song, upvotes_count: 0)
+
+      SongUpvoteService.upvote!(song, insert(:user))
+      SongUpvoteService.upvote!(song, insert(:user))
+
+      assert Repo.get(Song, song.id).upvotes_count == 2
+    end
+  end
+
+  ##############################################################################
+  # remove_upvote!/2
+  describe "remove_upvote!/2" do
+    test "removes the user's upvote and decrements the upvotes_count" do
+      user = insert(:user)
+      song = insert(:song, upvotes_count: 1)
+      insert(:song_upvote, user: user, song: song)
+
+      SongUpvoteService.remove_upvote!(song, user)
+
+      refute Repo.exists?(from u in SongUpvote, where: u.user_id == ^user.id and u.song_id == ^song.id)
+      assert Repo.get(Song, song.id).upvotes_count == 0
+    end
+
+    test "only removes the current user's upvote of the song" do
+      user = insert(:user)
+      song = insert(:song, upvotes_count: 2)
+      insert(:song_upvote, user: user, song: song)
+      other_upvote = insert(:song_upvote, song: song)
+      my_other_upvote = insert(:song_upvote, user: user)
+
+      SongUpvoteService.remove_upvote!(song, user)
+
+      assert Repo.get(SongUpvote, other_upvote.id)
+      assert Repo.get(SongUpvote, my_other_upvote.id)
+      assert Repo.get(Song, song.id).upvotes_count == 1
+    end
+
+    test "does nothing when the user has not upvoted the song" do
+      user = insert(:user)
+      song = insert(:song, upvotes_count: 0)
+
+      SongUpvoteService.remove_upvote!(song, user)
+
+      assert Repo.get(Song, song.id).upvotes_count == 0
+    end
+  end
+
+  ##############################################################################
+  # delete_upvotes_for_user!/1
+  describe "delete_upvotes_for_user!/1" do
+    test "deletes all of the user's upvotes and decrements the counters of the affected songs" do
+      user = insert(:user)
+      song_1 = insert(:song, upvotes_count: 2)
+      song_2 = insert(:song, upvotes_count: 1)
+      insert(:song_upvote, user: user, song: song_1)
+      other_upvote = insert(:song_upvote, song: song_1)
+      insert(:song_upvote, user: user, song: song_2)
+
+      {:ok, _} = SongUpvoteService.delete_upvotes_for_user!(user)
+
+      refute Repo.exists?(from u in SongUpvote, where: u.user_id == ^user.id)
+      assert Repo.get(SongUpvote, other_upvote.id)
+      assert Repo.get(Song, song_1.id).upvotes_count == 1
+      assert Repo.get(Song, song_2.id).upvotes_count == 0
+    end
+
+    test "does nothing for a user without upvotes" do
+      song = insert(:song, upvotes_count: 1)
+      insert(:song_upvote, song: song)
+
+      {:ok, _} = SongUpvoteService.delete_upvotes_for_user!(insert(:user))
+
+      assert Repo.get(Song, song.id).upvotes_count == 1
+    end
+  end
+
+  ##############################################################################
+  # upvoted_song_ids/2
+  describe "upvoted_song_ids/2" do
+    test "returns the subset of song ids the user has upvoted" do
+      user = insert(:user)
+      upvoted = insert(:song)
+      not_upvoted = insert(:song)
+      insert(:song_upvote, user: user, song: upvoted)
+
+      assert SongUpvoteService.upvoted_song_ids(user, [upvoted.id, not_upvoted.id]) == [upvoted.id]
+    end
+
+    test "returns an empty list for a nil user or empty ids" do
+      assert SongUpvoteService.upvoted_song_ids(nil, [1, 2]) == []
+      assert SongUpvoteService.upvoted_song_ids(insert(:user), []) == []
+    end
+  end
+end

--- a/test/helheim_web/controllers/page_controller_test.exs
+++ b/test/helheim_web/controllers/page_controller_test.exs
@@ -54,6 +54,16 @@ defmodule HelheimWeb.PageControllerTest do
       assert response =~ gettext("Top songs, past 7 days")
     end
 
+    test "it shows the most upvoted songs of the past 24 hours and past 7 days even without recent listens", %{conn: conn} do
+      insert(:song_upvote, song: insert(:song, title: "Orion"))
+
+      conn = get conn, "/front_page"
+      response = html_response(conn, 200)
+      assert response =~ gettext("Most upvoted songs, past 24 hours")
+      assert response =~ gettext("Most upvoted songs, past 7 days")
+      assert response =~ "Orion"
+    end
+
     test "it does not show the same song twice in the recent listens", %{conn: conn} do
       user = insert(:user)
       song = insert(:song, title: "Orion")

--- a/test/helheim_web/controllers/song_controller_test.exs
+++ b/test/helheim_web/controllers/song_controller_test.exs
@@ -299,4 +299,132 @@ defmodule HelheimWeb.SongControllerTest do
       assert Repo.get(Helheim.SongListen, listen.id)
     end
   end
+
+  ##############################################################################
+  # top_upvoted_day/2 and top_upvoted_week/2
+  describe "top_upvoted_day/2 and top_upvoted_week/2 when signed in" do
+    setup [:create_and_sign_in_user]
+
+    test "it shows the most upvoted songs of the past 24 hours", %{conn: conn} do
+      insert(:song_upvote, song: insert(:song, title: "Creeping Death"))
+
+      response = conn |> get("/songs/top/upvoted/day") |> html_response(200)
+      assert response =~ "Creeping Death"
+      assert response =~ gettext("Most upvoted songs, past 24 hours")
+    end
+
+    test "it shows the most upvoted songs of the past 7 days", %{conn: conn} do
+      insert(:song_upvote, song: insert(:song, title: "Creeping Death"))
+
+      response = conn |> get("/songs/top/upvoted/week") |> html_response(200)
+      assert response =~ "Creeping Death"
+      assert response =~ gettext("Most upvoted songs, past 7 days")
+    end
+
+    test "it does not count upvotes from ignored users", %{conn: conn, user: user} do
+      ignoree = insert(:user)
+      insert(:ignore, ignorer: user, ignoree: ignoree, enabled: true)
+      insert(:song_upvote, user: ignoree, song: insert(:song, title: "Creeping Death"))
+
+      response = conn |> get("/songs/top/upvoted/day") |> html_response(200)
+      refute response =~ "Creeping Death"
+    end
+  end
+
+  describe "top_upvoted_day/2 and top_upvoted_week/2 when not signed in" do
+    test "it redirects to the sign in page", %{conn: conn} do
+      assert conn |> get("/songs/top/upvoted/day") |> redirected_to() =~ session_path(conn, :new)
+      assert conn |> get("/songs/top/upvoted/week") |> redirected_to() =~ session_path(conn, :new)
+    end
+  end
+
+  ##############################################################################
+  # upvote/2
+  describe "upvote/2 when signed in" do
+    setup [:create_and_sign_in_user]
+
+    test "it upvotes the song and increments its counter", %{conn: conn, user: user} do
+      song = insert(:song, upvotes_count: 0)
+
+      conn = post conn, "/songs/#{song.id}/upvote"
+
+      assert redirected_to(conn) == song_path(conn, :show, song)
+      assert Repo.get(Helheim.Song, song.id).upvotes_count == 1
+      assert Repo.exists?(from u in Helheim.SongUpvote, where: u.user_id == ^user.id and u.song_id == ^song.id)
+    end
+
+    test "it returns a 404 when the song does not exist", %{conn: conn} do
+      assert_error_sent :not_found, fn -> post conn, "/songs/1234567/upvote" end
+    end
+
+    test "it returns the resulting state as JSON for async requests", %{conn: conn} do
+      song = insert(:song, upvotes_count: 0)
+
+      conn =
+        conn
+        |> put_req_header("accept", "application/json")
+        |> post("/songs/#{song.id}/upvote")
+
+      assert json_response(conn, 200) == %{"upvoted" => true, "upvotes_count" => 1}
+    end
+
+    test "it returns the current state as JSON when the song was already upvoted", %{conn: conn, user: user} do
+      song = insert(:song, upvotes_count: 1)
+      insert(:song_upvote, user: user, song: song)
+
+      conn =
+        conn
+        |> put_req_header("accept", "application/json")
+        |> post("/songs/#{song.id}/upvote")
+
+      assert json_response(conn, 200) == %{"upvoted" => true, "upvotes_count" => 1}
+    end
+  end
+
+  describe "upvote/2 when not signed in" do
+    test "it redirects to the sign in page and does not upvote", %{conn: conn} do
+      song = insert(:song, upvotes_count: 0)
+      conn = post conn, "/songs/#{song.id}/upvote"
+      assert redirected_to(conn) =~ session_path(conn, :new)
+      assert Repo.get(Helheim.Song, song.id).upvotes_count == 0
+    end
+  end
+
+  ##############################################################################
+  # remove_upvote/2
+  describe "remove_upvote/2 when signed in" do
+    setup [:create_and_sign_in_user]
+
+    test "it removes the current user's upvote and decrements the counter", %{conn: conn, user: user} do
+      song = insert(:song, upvotes_count: 1)
+      insert(:song_upvote, user: user, song: song)
+
+      conn = delete conn, "/songs/#{song.id}/upvote"
+
+      assert redirected_to(conn) == song_path(conn, :show, song)
+      refute Repo.exists?(from u in Helheim.SongUpvote, where: u.user_id == ^user.id and u.song_id == ^song.id)
+      assert Repo.get(Helheim.Song, song.id).upvotes_count == 0
+    end
+
+    test "it returns the resulting state as JSON for async requests", %{conn: conn, user: user} do
+      song = insert(:song, upvotes_count: 1)
+      insert(:song_upvote, user: user, song: song)
+
+      conn =
+        conn
+        |> put_req_header("accept", "application/json")
+        |> delete("/songs/#{song.id}/upvote")
+
+      assert json_response(conn, 200) == %{"upvoted" => false, "upvotes_count" => 0}
+    end
+  end
+
+  describe "remove_upvote/2 when not signed in" do
+    test "it redirects to the sign in page and does not remove any upvotes", %{conn: conn} do
+      upvote = insert(:song_upvote)
+      conn = delete conn, "/songs/#{upvote.song_id}/upvote"
+      assert redirected_to(conn) =~ session_path(conn, :new)
+      assert Repo.get(Helheim.SongUpvote, upvote.id)
+    end
+  end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -259,4 +259,11 @@ defmodule Helheim.Factory do
       played_at: sequence(:played_at, &Timex.shift(Timex.now, seconds: -&1))
     }
   end
+
+  def song_upvote_factory do
+    %Helheim.SongUpvote{
+      user: build(:user),
+      song: build(:song)
+    }
+  end
 end


### PR DESCRIPTION
## What

Adds song upvoting ("likes") to the music feature:

- **Upvote badge** on every song listing (front page cards, recent listens, profile pages, user music pages, chart pages) and the song detail page. It matches the comment/listen count badges: a hand-horns icon (inline MIT-licensed SVG — the glyph isn't in Font Awesome's free set) plus the song's all-time upvote count, highlighted when you've upvoted.
- **Async voting** via `assets/js/song_upvote.js`: no page reload. The server returns the resulting state as JSON and every badge for that song on the page snaps to it. An expired session navigates to sign-in; other failures briefly flash the badge red.
- **Two new front page charts** — most upvoted songs over the past 24 hours and past 7 days — with matching full-list pages (`/songs/top/upvoted/day|week`), ranked by a rolling window and cached like the listen charts. All four chart cards share a new `_chart_card` partial. Windowed upvote counts render as a separate plain badge (`fa-fire`) so the toggle's number always means the same thing (all-time total).
- **Danish translations** included ("Like" / "Fjern like" / "Mest likede sange", per the 2009 dictionary sense of the loanword).

## How

- New `song_upvotes` table, unique per `(user_id, song_id)`, with a composite `(inserted_at, song_id)` index for the windowed chart query, plus an `upvotes_count` counter cache on `songs`.
- `SongUpvoteService` toggles votes in an `Ecto.Multi` keeping the counter in sync (idempotent in both directions), and batch-loads the viewer's upvoted ids per page — it accepts songs, chart rows, listens, or ids, so every controller uses the same one-liner.
- Account deletion decrements the counters before the FK cascade, in one transaction with the user delete, mirroring the existing `listens_count` handling.
- Votes invalidate the cached charts (including the listen charts, whose cached rows embed song structs the badge reads counts from — a documented freshness/efficiency tradeoff). `Helheim.Cache` gained per-prefix generation counters so an in-flight chart computation can't re-insert a stale result after invalidation.

## Reviewer notes

- The vote endpoints use the `Accept: application/json` negotiation already declared in the `:browser` pipeline; non-JSON requests get a plain redirect to the song. Unexpected transaction failures crash (500) rather than reporting success — only the expected duplicate-vote conflict is tolerated, returning current state so stale pages resync.
- `upvote_toggle` requires the `upvoted_song_ids` assign (`Map.fetch!`) so a future page that forgets it fails loudly in dev/test instead of rendering wrong button state.
- The migration was applied to the dev database; run `mix ecto.migrate` for other environments.
- Test suite: 1605 tests, 0 failures. The async flows (state sync, error flash, signed-out redirect) were additionally exercised in a browser against the compiled bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)