### PR TITLE
Make admin tables horizontally scrollable on small screens

### DIFF
--- a/lib/helheim_web/templates/admin/term/index.html.eex
+++ b/lib/helheim_web/templates/admin/term/index.html.eex
@@ -8,6 +8,7 @@
   <%= gettext("Create New Terms") %>
 <% end %>
 
+<div class="table-responsive">
 <table class="table">
   <thead>
     <tr>
@@ -40,3 +41,4 @@
     <% end %>
   </tbody>
 </table>
+</div>

--- a/lib/helheim_web/templates/admin/user/_blocks.html.eex
+++ b/lib/helheim_web/templates/admin/user/_blocks.html.eex
@@ -1,6 +1,7 @@
 <h4><%= gettext "Blocks" %>:</h4>
 
 <%= if Enum.any?(@blocks) do %>
+  <div class="table-responsive">
   <table class="table">
     <thead>
       <tr>
@@ -26,6 +27,7 @@
       <% end %>
     </tbody>
   </table>
+  </div>
 <% else %>
   <hr>
   <p class="text-center">

--- a/lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex
+++ b/lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex
@@ -1,6 +1,7 @@
 <h4><%= gettext "Recent blog posts" %>:</h4>
 
 <%= if Enum.any?(@recent_blog_posts) do %>
+  <div class="table-responsive">
   <table class="table">
     <thead>
       <tr>
@@ -32,6 +33,7 @@
       <% end %>
     </tbody>
   </table>
+  </div>
 <% else %>
   <hr>
   <p class="text-center">

--- a/lib/helheim_web/templates/admin/user/_recent_comments.html.eex
+++ b/lib/helheim_web/templates/admin/user/_recent_comments.html.eex
@@ -1,6 +1,7 @@
 <h4><%= gettext "Recent comments" %>:</h4>
 
 <%= if Enum.any?(@recent_comments) do %>
+  <div class="table-responsive">
   <table class="table">
     <thead>
       <tr>
@@ -23,6 +24,7 @@
       <% end %>
     </tbody>
   </table>
+  </div>
 <% else %>
   <hr>
   <p class="text-center">

--- a/lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex
+++ b/lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex
@@ -1,6 +1,7 @@
 <h4><%= gettext "Recent forum replies" %>:</h4>
 
 <%= if Enum.any?(@recent_forum_replies) do %>
+  <div class="table-responsive">
   <table class="table">
     <thead>
       <tr>
@@ -26,6 +27,7 @@
       <% end %>
     </tbody>
   </table>
+  </div>
 <% else %>
   <hr>
   <p class="text-center">

--- a/lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex
+++ b/lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex
@@ -1,6 +1,7 @@
 <h4><%= gettext "Recent forum topics" %>:</h4>
 
 <%= if Enum.any?(@recent_forum_topics) do %>
+  <div class="table-responsive">
   <table class="table">
     <thead>
       <tr>
@@ -26,6 +27,7 @@
       <% end %>
     </tbody>
   </table>
+  </div>
 <% else %>
   <hr>
   <p class="text-center">

--- a/lib/helheim_web/templates/admin/user/_users.html.eex
+++ b/lib/helheim_web/templates/admin/user/_users.html.eex
@@ -1,3 +1,4 @@
+<div class="table-responsive">
 <table class="table table-striped">
   <thead>
     <tr>
@@ -50,3 +51,4 @@
   </tbody>
 
 </table>
+</div>


### PR DESCRIPTION
## What

Wrap the admin tables in Bootstrap's `.table-responsive` container so wide tables scroll horizontally within their own box on narrow viewports.

## Why

On small screens the user-admin index table extended past the viewport with no way to scroll horizontally, making it impossible to administrate users from a phone.

## Changes

Added a `.table-responsive` wrapper around the tables in:

- `admin/user/_users.html.eex` — user index
- `admin/term/index.html.eex` — terms index
- `admin/user/_recent_blog_posts.html.eex`
- `admin/user/_recent_forum_replies.html.eex`
- `admin/user/_recent_forum_topics.html.eex`
- `admin/user/_recent_comments.html.eex`
- `admin/user/_blocks.html.eex`

The recent-* and `_blocks` partials render on the user **show** page, so that admin detail view is now phone-friendly too.

## Notes for reviewers

- `.table-responsive` (`overflow-x: auto`) is already in the bundled Bootstrap CSS (`assets/vendor/css/bootstrap_src/_tables.scss`), so no asset rebuild is required.
- On wide screens there is no visible change — the scrollbar only appears when a table actually overflows.
- Template-only (`.eex`) edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved responsive behavior for administrative tables, including terms, users, blocks, blog posts, comments, forum replies, and forum topics.
  - Tables now adapt more effectively to smaller screens without changing their displayed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->