### PR TITLE
Add a dedicated music page and slim music down on the front page

### DIFF
--- a/assets/css/_custom.scss
+++ b/assets/css/_custom.scss
@@ -58,6 +58,14 @@ label {
   }
 }
 
+// The front page clips its avatar grid (140 avatars) to a few rows; the listener
+// and upvoter grids on a song page are short and left-aligned, so they show in
+// full.
+.avatar-list-full {
+  max-height: none;
+  justify-content: flex-start;
+}
+
 form.link {
   display: inline;
 }
@@ -377,4 +385,88 @@ code {
   }
 }
 
+// Full page song lists (the charts, the recent listens, the browse pages) show
+// large cover art in a grid rather than the 64px thumbnails the summary cards on
+// the front page and the music page use. auto-fill holds the tile size roughly
+// constant and lets the column count follow the available width, so the same
+// grid works from a phone to a wide screen with a sidebar.
+.song-grid {
+  display: grid;
+  // 120px is what it takes to keep two covers per row on a narrow phone, where
+  // the card's own padding leaves under 280px to lay them out in; from sm up
+  // there is room for a tile size that shows the cover art off properly.
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 1rem;
+  margin-bottom: $spacer-y;
+
+  @include media-breakpoint-up(sm) {
+    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  }
+}
+
+.song-grid-item {
+  // A grid item defaults to min-content width, which would stop the titles from
+  // ever ellipsising and let a long one widen its whole column instead.
+  min-width: 0;
+
+  // The overlay is sized for a 64px thumbnail by default; on a cover this large
+  // it needs to grow with it to stay an obvious target.
+  .song-preview-overlay {
+    bottom: 0.5rem;
+    left: 0.5rem;
+    width: 36px;
+    height: 36px;
+
+    i {
+      font-size: 1rem;
+    }
+  }
+
+  a:hover .song-grid-cover {
+    border-color: $brand-primary;
+  }
+}
+
+.song-grid-cover {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  border: 1px solid $gray;
+  object-fit: cover;
+  transition: 0.1s ease-in-out;
+}
+
+.song-grid-cover-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.25);
+
+  i {
+    font-size: 2rem;
+    opacity: 0.5;
+  }
+}
+
+.song-grid-body {
+  margin-top: 0.5 * $spacer-y;
+}
+
+// Muted like the artist name on the summary rows, but still clearly a link on
+// hover. Bootstrap's .text-muted would work for the colour but darkens on hover,
+// which on this theme's near-black muted colour reads as the link disappearing.
+.song-grid-artist {
+  color: $text-muted;
+
+  &:hover,
+  &:focus {
+    color: $brand-primary;
+  }
+}
+
+.song-grid-badges {
+  margin-top: 0.25 * $spacer-y;
+}
+
 @import "calendar_events";
+@import "music";

--- a/assets/css/_music.scss
+++ b/assets/css/_music.scss
@@ -1,0 +1,199 @@
+// The music page's own visualisations. The song rows, chart cards and covers on
+// the page are the shared song partials and need nothing here.
+
+.music-stats {
+  display: flex;
+  flex-wrap: wrap;
+  // Absorbs the bottom margin of the last row of tiles, so they sit flush with
+  // the bottom of the card block however many rows they wrap onto.
+  margin-bottom: -0.5 * $spacer-y;
+
+  // The callout brings its own vertical rhythm for stacked use; here the tiles
+  // are laid out side by side instead.
+  .callout {
+    flex: 1 1 33%;
+    margin: 0 0 0.5 * $spacer-y;
+    padding: 0 0.5 * $spacer-x;
+  }
+
+  // Three tiles per row is as narrow as the numbers stay readable; from md
+  // there is room for all of them on one line.
+  @include media-breakpoint-up(md) {
+    .callout {
+      flex: 1 1 0;
+    }
+  }
+}
+
+// Genres and decades sit side by side from md up. The row already makes the two
+// columns the same height, but the cards inside them were not, so whichever chart
+// was shorter floated above a band of page background. Stretching the card fills
+// that, and the flex chain from here down lets the decade track claim whatever
+// height is left over, so the two charts end flush instead of one just being
+// padded out.
+.music-charts {
+  > [class*="col-"] {
+    display: flex;
+  }
+
+  .card {
+    width: 100%;
+  }
+
+  .card-block {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.music-bar {
+  display: block;
+  margin-bottom: 0.5 * $spacer-y;
+  color: $body-color;
+
+  &:hover {
+    color: $brand-primary;
+    text-decoration: none;
+  }
+
+  .progress {
+    margin-bottom: 0;
+  }
+}
+
+.music-bar-label {
+  display: flex;
+  justify-content: space-between;
+
+  // A long genre name has to ellipsise instead of pushing the count out of the
+  // row, and a flex item needs an explicit min-width to be allowed to shrink
+  // below its content.
+  .music-bar-name {
+    min-width: 0;
+  }
+
+  // The count belongs to the bar underneath it, so the shared count badge keeps
+  // its typography but drops the pill: no background, and no padding, which also
+  // lines the number up with the end of the bar.
+  .badge {
+    padding: 0;
+    background-color: transparent;
+  }
+}
+
+.music-decades {
+  display: flex;
+  // Takes the height the heading leaves behind, which is what gives the bars
+  // room to grow when the chart beside this one is the taller of the two.
+  flex: 1 1 auto;
+}
+
+.music-decade {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  min-width: 0;
+  padding: 0 2px;
+  color: $body-color;
+  text-align: center;
+
+  &:hover {
+    color: $brand-primary;
+    text-decoration: none;
+
+    .music-decade-bar {
+      background-color: lighten($brand-primary, 15%);
+    }
+  }
+}
+
+// The track grows into whatever height the card has spare, so the equalizer
+// stretches to match a taller neighbour rather than leaving the card padded out.
+// The min-height is the floor it falls back to when nothing else is setting the
+// card's height - a stacked phone layout, or when this is the taller chart - and
+// it is also what the bars' percentage heights resolve against.
+.music-decade-track {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: flex-end;
+  min-height: 140px;
+
+  @include media-breakpoint-down(xs) {
+    min-height: 100px;
+  }
+}
+
+.music-decade-bar {
+  width: 100%;
+  min-height: 2px;
+  background-color: $brand-primary;
+
+  @include border-radius($border-radius);
+}
+
+.music-decade-count,
+.music-decade-label {
+  display: block;
+  font-size: 0.75rem;
+}
+
+.music-decade-label {
+  font-weight: bold;
+}
+
+.music-rank {
+  min-width: 1.5rem;
+  color: $brand-primary;
+  font-weight: bold;
+}
+
+.music-artist {
+  display: block;
+  color: $body-color;
+  text-align: center;
+
+  &:hover {
+    color: $brand-primary;
+    text-decoration: none;
+
+    .music-artist-image {
+      border-color: $brand-primary;
+    }
+  }
+}
+
+.music-artist-image {
+  display: block;
+  width: 100%;
+  // Capped and centred so the three podium tiles stay a visual anchor instead of
+  // taking over the section on a wide screen, while still shrinking on a phone.
+  max-width: 200px;
+  margin: 0 auto;
+  aspect-ratio: 1;
+  border: 1px solid $gray;
+  object-fit: cover;
+  transition: 0.1s ease-in-out;
+}
+
+.music-artist-image-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.25);
+
+  i {
+    font-size: 2rem;
+    opacity: 0.5;
+  }
+}
+
+// The artist page header shows the same square image as the grid tiles, at a
+// fixed size beside the artist's details.
+.music-artist-header-image {
+  flex: 0 0 auto;
+  width: 96px;
+
+  @include media-breakpoint-up(md) {
+    width: 140px;
+  }
+}

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,6 +17,7 @@ config :helheim, Oban, testing: :manual
 
 # Never serve stale chart data across tests
 config :helheim, :chart_cache_ttl_ms, 0
+config :helheim, :music_stats_cache_ttl_ms, 0
 
 # Never cache external API responses across tests
 config :helheim, :api_cache_ttl_ms, 0

--- a/lib/helheim/models/artist.ex
+++ b/lib/helheim/models/artist.ex
@@ -2,6 +2,7 @@ defmodule Helheim.Artist do
   use Helheim, :model
 
   alias Helheim.Artist
+  alias Helheim.Repo
 
   schema "artists" do
     field :name,             :string
@@ -35,5 +36,25 @@ defmodule Helheim.Artist do
   def by_names(query, names) do
     downcased = Enum.map(names, &String.downcase/1)
     from a in query, where: fragment("lower(?)", a.name) in ^downcased
+  end
+
+  @doc """
+  Joins aggregated `{artist_name, count}` rows to their enriched artist records
+  (images, nationality) in a single lookup, producing
+  `{artist_name, count, artist_or_nil}`. Names with no artist record - not
+  enriched yet, or enrichment came back empty - still come through, just
+  without the extras.
+  """
+  def with_records([]), do: []
+  def with_records(rows) do
+    artists_by_name =
+      Artist
+      |> by_names(Enum.map(rows, fn {artist_name, _count} -> artist_name end))
+      |> Repo.all()
+      |> Map.new(fn artist -> {String.downcase(artist.name), artist} end)
+
+    Enum.map(rows, fn {artist_name, count} ->
+      {artist_name, count, artists_by_name[String.downcase(artist_name)]}
+    end)
   end
 end

--- a/lib/helheim/models/song.ex
+++ b/lib/helheim/models/song.ex
@@ -30,6 +30,12 @@ defmodule Helheim.Song do
     timestamps(type: :utc_datetime_usec)
   end
 
+  # Metadata sources occasionally hand back a nonsense release year; the decade
+  # breakdown clamps to years that could plausibly be a recording so a single
+  # bad row cannot add an "0s" or "3020s" column to the chart.
+  @earliest_release_year 1900
+  @latest_release_year 2100
+
   @metadata_fields [:album_name, :cover_image_url, :cover_image_url_small, :lastfm_track_url, :mbid, :artist_mbid, :album_mbid]
   @enrichment_fields [:cover_image_url_large, :release_year, :duration_seconds, :deezer_id, :enriched_at]
 
@@ -88,5 +94,70 @@ defmodule Helheim.Song do
       group_by: s.artist_name,
       order_by: [desc: count(l.id), asc: s.artist_name],
       select: {s.artist_name, count(l.id)}
+  end
+
+  @doc """
+  Artist names ordered by total listens, all time and site wide, as
+  `{artist_name, listen_count}`.
+
+  Grouped by `lower(artist_name)`, not `artist_name`: the songs unique index is
+  on `(lower(artist_name), lower(title))`, so two songs by the same artist can
+  legitimately be stored with different casing and a raw group_by would split
+  the artist in two. `min(artist_name)` then picks one spelling
+  deterministically.
+  """
+  def top_artists_by_listens(query) do
+    from s in query,
+      where: s.listens_count > 0,
+      group_by: fragment("lower(?)", s.artist_name),
+      order_by: [desc: sum(s.listens_count), asc: fragment("lower(?)", s.artist_name)],
+      select: {min(s.artist_name), sum(s.listens_count)}
+  end
+
+  @doc """
+  Listens grouped by the decade a song was released in, as
+  `{decade, listen_count}` ascending by decade. Songs with no release year -
+  not enriched yet, or the metadata sources had no year - are left out
+  entirely rather than bucketed as unknown.
+  """
+  def listens_per_decade(query) do
+    from s in query,
+      where: s.release_year >= ^@earliest_release_year and s.release_year <= ^@latest_release_year,
+      where: s.listens_count > 0,
+      group_by: selected_as(:decade),
+      order_by: [asc: selected_as(:decade)],
+      select: {selected_as(fragment("(? / 10) * 10", s.release_year), :decade), sum(s.listens_count)}
+  end
+
+  @doc """
+  Songs whose genre - the tag at `position: 1` - is the tag with the given id.
+  """
+  def for_genre(query, tag_id) do
+    from s in query,
+      join: st in Helheim.SongTag, on: st.song_id == s.id,
+      where: st.tag_id == ^tag_id and st.position == 1
+  end
+
+  @doc """
+  Songs released in the ten years starting at `decade`, so 1980 covers 1980
+  through 1989. A song with no release year fails the comparison and is left
+  out without needing an explicit check.
+  """
+  def for_decade(query, decade) when is_integer(decade) do
+    from s in query, where: s.release_year >= ^decade and s.release_year < ^(decade + 10)
+  end
+
+  @doc """
+  Songs by the given artist, matched case-insensitively on `artist_name` - the
+  same identity rule the artists table uses, and `artist_id` is no substitute
+  since it stays nil until enrichment runs. Uses the leading column of the
+  `songs_artist_title_index`.
+  """
+  def for_artist_name(query, artist_name) do
+    from s in query, where: fragment("lower(?)", s.artist_name) == ^String.downcase(artist_name)
+  end
+
+  def most_listened(query) do
+    from s in query, order_by: [desc: s.listens_count, asc: s.id]
   end
 end

--- a/lib/helheim/models/song_listen.ex
+++ b/lib/helheim/models/song_listen.ex
@@ -36,6 +36,21 @@ defmodule Helheim.SongListen do
     from l in subquery(deduplicated)
   end
 
+  @doc """
+  Collapses the listens to one per user, keeping the newest listen of each, so
+  a listener who played the song on repeat only takes up one spot in a listener
+  grid. Like `latest_per_song/1`, the caller must re-apply `newest/1` after this
+  - the ordering here is consumed by the subquery.
+  """
+  def latest_per_user(query) do
+    deduplicated =
+      from l in query,
+        distinct: l.user_id,
+        order_by: [asc: l.user_id, desc: l.played_at]
+
+    from l in subquery(deduplicated)
+  end
+
   def not_from_users(query, nil), do: query
   def not_from_users(query, user_ids) do
     from l in query, where: l.user_id not in ^user_ids

--- a/lib/helheim/models/song_upvote.ex
+++ b/lib/helheim/models/song_upvote.ex
@@ -20,4 +20,13 @@ defmodule Helheim.SongUpvote do
   def for_song(query, song) do
     from u in query, where: u.song_id == ^song.id
   end
+
+  def newest(query) do
+    from u in query, order_by: [desc: u.inserted_at]
+  end
+
+  def not_from_users(query, nil), do: query
+  def not_from_users(query, user_ids) do
+    from u in query, where: u.user_id not in ^user_ids
+  end
 end

--- a/lib/helheim/models/tag.ex
+++ b/lib/helheim/models/tag.ex
@@ -1,6 +1,8 @@
 defmodule Helheim.Tag do
   use Helheim, :model
 
+  alias Helheim.Song
+  alias Helheim.SongTag
   alias Helheim.Tag
 
   schema "tags" do
@@ -24,4 +26,24 @@ defmodule Helheim.Tag do
   def get_or_create_by_name!(name), do: Helheim.NamedLookup.get_or_create!(Tag, name)
 
   def get_by_name(name), do: Helheim.NamedLookup.get(Tag, name)
+
+  @doc """
+  Tags used as a genre - the tag at `position: 1` on a song, the one the song
+  page labels "Genre" - ordered by how many listens the songs carrying them
+  have, descending.
+
+  Sums the denormalized `songs.listens_count` rather than counting listen
+  rows: with no time window to narrow it down, counting rows would mean
+  reading every listen on the site. Songs that have never been played are
+  left out entirely, so a genre only appears once somebody has played it.
+  """
+  def top_by_listens(query) do
+    from t in query,
+      join: st in SongTag, on: st.tag_id == t.id,
+      join: s in Song, on: s.id == st.song_id,
+      where: st.position == 1 and s.listens_count > 0,
+      group_by: t.id,
+      order_by: [desc: sum(s.listens_count), asc: t.id],
+      select: {t, sum(s.listens_count)}
+  end
 end

--- a/lib/helheim/music/charts.ex
+++ b/lib/helheim/music/charts.ex
@@ -67,6 +67,11 @@ defmodule Helheim.Music.Charts do
   of being capped by the ttl. If chart queries ever show up in monitoring,
   the listen charts can be dropped from this list at the cost of vote
   counts inside them lagging up to one ttl.
+
+  The rule for anything added here later: a cached value belongs on this
+  list only if it embeds a `Song`, and therefore an `upvotes_count` that a
+  badge renders. The all time aggregates in `Helheim.Music.Stats` embed no
+  songs and are deliberately left out - see that module's moduledoc.
   """
   def invalidate_cache do
     Enum.each(

--- a/lib/helheim/music/stats.ex
+++ b/lib/helheim/music/stats.ex
@@ -1,0 +1,92 @@
+defmodule Helheim.Music.Stats do
+  @moduledoc """
+  All time, site wide music aggregates for the music page: the top genres, the
+  top artists, listens per decade, and the totals behind the stat tiles.
+
+  Unlike `Helheim.Music.Charts` these have no time window, so they sum the
+  denormalized `songs.listens_count` instead of counting `song_listens` rows.
+  That counter is kept exact by `Helheim.Lastfm.SyncService` and
+  `Helheim.LastfmAccountService`, and it is the same counter the genre, decade
+  and artist listings order by, so the music page and the pages it links to
+  cannot disagree. Counting rows would mean reading the whole `song_listens`
+  table on every recompute.
+
+  Also unlike the charts, these are not personalized by the viewer's ignore
+  list. A genre bar, a decade bar and an artist name attribute no content to
+  any user, so there is nothing of an ignored user's to hide - which in turn
+  means every result here is cacheable for every viewer.
+
+  Nothing here is dropped when a vote is cast, and it deliberately stays out of
+  `Helheim.Music.Charts.invalidate_cache/0`: no `Song` struct is embedded in
+  these results, so no upvote badge is rendered from them, and the upvote tile
+  is a site wide total that nobody can tell is a few minutes stale.
+  """
+
+  import Ecto.Query
+  alias Helheim.Artist
+  alias Helheim.Cache
+  alias Helheim.Repo
+  alias Helheim.Song
+  alias Helheim.SongListen
+  alias Helheim.Tag
+
+  def top_genres(count) do
+    Cache.fetch({:music_top_genres, count}, cache_ttl(), fn ->
+      Tag
+      |> Tag.top_by_listens()
+      |> limit(^count)
+      |> Repo.all()
+    end)
+  end
+
+  def top_artists(count) do
+    Cache.fetch({:music_top_artists, count}, cache_ttl(), fn ->
+      Song
+      |> Song.top_artists_by_listens()
+      |> limit(^count)
+      |> Repo.all()
+      |> Artist.with_records()
+    end)
+  end
+
+  def listens_per_decade do
+    Cache.fetch({:music_listens_per_decade, :all}, cache_ttl(), fn ->
+      Song
+      |> Song.listens_per_decade()
+      |> Repo.all()
+    end)
+  end
+
+  @doc """
+  The numbers behind the stat tiles: how many songs, artists, listens, upvotes
+  and listeners the site has.
+
+  Artists are counted as distinct `lower(artist_name)` across songs rather than
+  as rows in `artists`, so the tile agrees with `top_artists/1`; the artists
+  table only holds the names enrichment has already reached.
+  """
+  def totals do
+    Cache.fetch({:music_totals, :all}, cache_ttl(), &compute_totals/0)
+  end
+
+  defp compute_totals do
+    # sum/1 over zero rows is NULL, and an empty database is the realistic
+    # first case, so every sum is coalesced to a number the tiles can render.
+    song_totals =
+      Repo.one(
+        from s in Song,
+          select: %{
+            songs: count(s.id),
+            listens: coalesce(sum(s.listens_count), 0),
+            upvotes: coalesce(sum(s.upvotes_count), 0),
+            artists: fragment("count(distinct lower(?))", s.artist_name)
+          }
+      )
+
+    listeners = Repo.one(from l in SongListen, select: count(l.user_id, :distinct))
+
+    Map.put(song_totals, :listeners, listeners)
+  end
+
+  defp cache_ttl, do: Application.get_env(:helheim, :music_stats_cache_ttl_ms, :timer.minutes(5))
+end

--- a/lib/helheim_web.ex
+++ b/lib/helheim_web.ex
@@ -67,6 +67,7 @@ defmodule HelheimWeb do
       import HelheimWeb.CommentHelpers
       import HelheimWeb.VisibilityHelpers
       import HelheimWeb.TableHelpers
+      import HelheimWeb.MusicHelpers
     end
   end
 

--- a/lib/helheim_web/controllers/music_controller.ex
+++ b/lib/helheim_web/controllers/music_controller.ex
@@ -1,0 +1,147 @@
+defmodule HelheimWeb.MusicController do
+  use HelheimWeb, :controller
+  alias Helheim.Artist
+  alias Helheim.Song
+  alias Helheim.SongUpvoteService
+  alias Helheim.Tag
+  alias Helheim.Music.Charts
+  alias Helheim.Music.Stats
+
+  @top_genres_count 10
+  @top_artists_count 12
+  @chart_count 5
+
+  def index(conn, _params) do
+    excluded_user_ids = conn.assigns[:ignoree_ids]
+
+    top_songs_day    = Charts.top_songs_last_day(@chart_count, excluded_user_ids)
+    top_songs_week   = Charts.top_songs_last_week(@chart_count, excluded_user_ids)
+    top_upvoted_day  = Charts.top_upvoted_songs_last_day(@chart_count, excluded_user_ids)
+    top_upvoted_week = Charts.top_upvoted_songs_last_week(@chart_count, excluded_user_ids)
+
+    upvoted_song_ids =
+      SongUpvoteService.upvoted_song_ids(
+        current_resource(conn),
+        Enum.concat([top_songs_day, top_songs_week, top_upvoted_day, top_upvoted_week])
+      )
+
+    render conn, "index.html",
+      totals: Stats.totals(),
+      top_genres: Stats.top_genres(@top_genres_count),
+      top_artists: Stats.top_artists(@top_artists_count),
+      listens_per_decade: Stats.listens_per_decade(),
+      top_songs_day: top_songs_day,
+      top_songs_week: top_songs_week,
+      top_upvoted_day: top_upvoted_day,
+      top_upvoted_week: top_upvoted_week,
+      upvoted_song_ids: upvoted_song_ids
+  end
+
+  def genre(conn, %{"id" => id} = params) do
+    tag = Repo.get!(Tag, id)
+
+    songs =
+      Song
+      |> Song.for_genre(tag.id)
+      |> Song.most_listened()
+      |> paginate_songs(params)
+
+    render(conn, "genre.html", tag: tag, songs: songs, upvoted_song_ids: upvoted_song_ids(conn, songs))
+  end
+
+  # Decades are addressed by their first year (/music/decades/1980). Any other
+  # year inside the decade redirects to that canonical url, so a link built from
+  # a song's release year still lands somewhere sensible, and anything that is
+  # not a plausible year is a 404 - the same answer an unknown genre gets.
+  def decade(conn, %{"decade" => decade} = params) do
+    case Integer.parse(decade) do
+      {year, ""} when year in 1000..2999 ->
+        start_year = div(year, 10) * 10
+
+        if start_year == year do
+          songs =
+            Song
+            |> Song.for_decade(start_year)
+            |> Song.most_listened()
+            |> paginate_songs(params)
+
+          render(conn, "decade.html",
+            decade: start_year,
+            songs: songs,
+            upvoted_song_ids: upvoted_song_ids(conn, songs))
+        else
+          redirect(conn, to: music_path(conn, :decade, start_year))
+        end
+
+      _ ->
+        render_not_found(conn)
+    end
+  end
+
+  def artist(conn, %{"artist_name" => segments} = params) do
+    # Plug has already decoded each path segment, so rejoining them gives back
+    # a name that was written with a slash in it.
+    artist_name = Enum.join(segments, "/")
+    artist = Artist.get_by_name(artist_name)
+
+    songs =
+      Song
+      |> Song.for_artist_name(artist_name)
+      |> Song.most_listened()
+      |> paginate_songs(params)
+
+    # An artist url only means something if the site knows the name, from a song
+    # or from an enriched artist record; anything else is a made up url and gets
+    # a 404 rather than an empty shell. total_entries is what is checked, not
+    # the contents of this page, so a deep page number cannot turn a real artist
+    # into a 404.
+    if is_nil(artist) && songs.total_entries == 0 do
+      render_not_found(conn)
+    else
+      render(conn, "artist.html",
+        artist_name: display_artist_name(artist, songs, artist_name),
+        artist: artist,
+        listen_count: artist_listen_count(artist_name),
+        songs: songs,
+        upvoted_song_ids: upvoted_song_ids(conn, songs))
+    end
+  end
+
+  # The header shows the artist's listens across their whole catalogue, not just
+  # the songs on this page.
+  defp artist_listen_count(artist_name) do
+    Song
+    |> Song.for_artist_name(artist_name)
+    |> select([s], coalesce(sum(s.listens_count), 0))
+    |> Repo.one()
+  end
+
+  # The shared song list partial renders {song, count} rows like the chart pages
+  # do. These lists are ordered by the song's all time listen total, so that is
+  # the number the rows show.
+  defp paginate_songs(query, params) do
+    page = capped_paginate(query, params)
+    %{page | entries: Enum.map(page.entries, &{&1, &1.listens_count})}
+  end
+
+  defp upvoted_song_ids(conn, songs) do
+    SongUpvoteService.upvoted_song_ids(current_resource(conn), songs)
+  end
+
+  # Prefer the enriched artist record's spelling, then the spelling on the songs
+  # themselves; the name from the url is the last resort, since it is whatever
+  # casing the visitor happened to type.
+  defp display_artist_name(%Artist{} = artist, _songs, _artist_name), do: artist.name
+  defp display_artist_name(nil, %{entries: [{song, _count} | _]}, _artist_name), do: song.artist_name
+  defp display_artist_name(nil, _songs, artist_name), do: artist_name
+
+  # A url that names no decade or no artist is a bad url, not a missing record,
+  # so there is nothing for Repo.get! to raise about. The site's own 404 page is
+  # rendered directly instead, and it is a standalone document, hence no layout.
+  defp render_not_found(conn) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(HelheimWeb.ErrorView)
+    |> render("404.html", layout: false)
+  end
+end

--- a/lib/helheim_web/controllers/page_controller.ex
+++ b/lib/helheim_web/controllers/page_controller.ex
@@ -8,7 +8,6 @@ defmodule HelheimWeb.PageController do
   alias Helheim.CalendarEvent
   alias Helheim.SongListen
   alias Helheim.SongUpvoteService
-  alias Helheim.Music.Charts
 
   def index(conn, _params) do
     if Guardian.Plug.current_resource(conn) do
@@ -58,19 +57,12 @@ defmodule HelheimWeb.PageController do
       |> SongListen.latest_per_song
       |> SongListen.newest
       |> SongListen.with_preloads
-      |> limit(5)
+      # Fifteen, because the card lays them out in up to three columns of five -
+      # see HelheimWeb.PageView.recent_listen_columns/1.
+      |> limit(15)
       |> Repo.all
 
-    top_songs_day       = Charts.top_songs_last_day(5, conn.assigns[:ignoree_ids])
-    top_songs_week      = Charts.top_songs_last_week(5, conn.assigns[:ignoree_ids])
-    top_upvoted_day     = Charts.top_upvoted_songs_last_day(5, conn.assigns[:ignoree_ids])
-    top_upvoted_week    = Charts.top_upvoted_songs_last_week(5, conn.assigns[:ignoree_ids])
-
-    upvoted_song_ids =
-      SongUpvoteService.upvoted_song_ids(
-        current_resource(conn),
-        Enum.concat([recent_song_listens, top_songs_day, top_songs_week, top_upvoted_day, top_upvoted_week])
-      )
+    upvoted_song_ids = SongUpvoteService.upvoted_song_ids(current_resource(conn), recent_song_listens)
 
     render conn, "front_page.html",
       newest_users: newest_users,
@@ -79,10 +71,6 @@ defmodule HelheimWeb.PageController do
       newest_forum_topics: newest_forum_topics,
       upcoming_events: upcoming_events,
       recent_song_listens: recent_song_listens,
-      top_songs_day: top_songs_day,
-      top_songs_week: top_songs_week,
-      top_upvoted_day: top_upvoted_day,
-      top_upvoted_week: top_upvoted_week,
       upvoted_song_ids: upvoted_song_ids
   end
 

--- a/lib/helheim_web/controllers/song_controller.ex
+++ b/lib/helheim_web/controllers/song_controller.ex
@@ -6,11 +6,14 @@ defmodule HelheimWeb.SongController do
   alias Helheim.Deezer
   alias Helheim.Song
   alias Helheim.SongListen
+  alias Helheim.SongUpvote
   alias Helheim.SongUpvoteService
   alias Helheim.Music.Charts
 
-  # The full list pages are capped at 100 pages to preserve performance.
-  @max_pages 100
+  # The listener and upvoter grids on a song page show avatars, so they fit far
+  # more names than the old text list did - but still a bounded number, which is
+  # what lets them skip pagination.
+  @grid_limit 50
 
   def recent(conn, params) do
     listens =
@@ -62,13 +65,24 @@ defmodule HelheimWeb.SongController do
       |> Repo.get!(id)
       |> Repo.preload(song_tags: {Helheim.SongTag.ordered(Helheim.SongTag), [:tag]})
     current_user = current_resource(conn)
+    # Hoisted: this runs a query of its own and both grids need the same answer.
+    hidden_user_ids = hidden_user_ids(conn, current_user)
     recent_listens =
       SongListen
       |> SongListen.for_song(song)
+      |> SongListen.not_from_users(hidden_user_ids)
+      |> SongListen.latest_per_user
       |> SongListen.newest
-      |> SongListen.not_from_users(hidden_user_ids(conn, current_user))
       |> preload(:user)
-      |> limit(10)
+      |> limit(@grid_limit)
+      |> Repo.all
+    recent_upvotes =
+      SongUpvote
+      |> SongUpvote.for_song(song)
+      |> SongUpvote.not_from_users(hidden_user_ids)
+      |> SongUpvote.newest
+      |> preload(:user)
+      |> limit(@grid_limit)
       |> Repo.all
     comments =
       assoc(song, :comments)
@@ -84,6 +98,7 @@ defmodule HelheimWeb.SongController do
     render(conn, "show.html",
       song: song,
       recent_listens: recent_listens,
+      recent_upvotes: recent_upvotes,
       comments: comments,
       current_user_has_listens: current_user_has_listens,
       upvoted_song_ids: SongUpvoteService.upvoted_song_ids(current_user, [song]))
@@ -161,12 +176,6 @@ defmodule HelheimWeb.SongController do
     conn
     |> put_flash(:success, gettext("Your listens have been removed from this song."))
     |> redirect(to: song_path(conn, :show, song))
-  end
-
-  defp capped_paginate(query, params) do
-    query
-    |> Repo.paginate(page: sanitized_page(params["page"], @max_pages))
-    |> cap_total_pages(@max_pages)
   end
 
   # Users the viewer ignores, plus users who block the viewer, are left out

--- a/lib/helheim_web/controllers/song_listen_controller.ex
+++ b/lib/helheim_web/controllers/song_listen_controller.ex
@@ -1,5 +1,6 @@
 defmodule HelheimWeb.SongListenController do
   use HelheimWeb, :controller
+  alias Helheim.Artist
   alias Helheim.Song
   alias Helheim.SongListen
   alias Helheim.User
@@ -24,7 +25,7 @@ defmodule HelheimWeb.SongListenController do
       if page == 1 do
         {
           Song |> Song.top_for_user(user) |> limit(10) |> Repo.all,
-          Song |> Song.top_artists_for_user(user) |> limit(10) |> Repo.all |> with_artist_records()
+          Song |> Song.top_artists_for_user(user) |> limit(10) |> Repo.all |> Artist.with_records()
         }
       else
         {nil, nil}
@@ -42,24 +43,6 @@ defmodule HelheimWeb.SongListenController do
       top_songs: top_songs,
       top_artists: top_artists,
       upvoted_song_ids: upvoted_song_ids)
-  end
-
-  # Joins the aggregated {artist_name, count} rows with their enriched
-  # artist records (images, nationality) in a single lookup. Songs whose
-  # artist has not been enriched yet still appear, just without extras.
-  defp with_artist_records([]), do: []
-  defp with_artist_records(top_artists) do
-    names = Enum.map(top_artists, fn {artist_name, _count} -> artist_name end)
-
-    artists_by_name =
-      Helheim.Artist
-      |> Helheim.Artist.by_names(names)
-      |> Repo.all()
-      |> Map.new(fn artist -> {String.downcase(artist.name), artist} end)
-
-    Enum.map(top_artists, fn {artist_name, count} ->
-      {artist_name, count, artists_by_name[String.downcase(artist_name)]}
-    end)
   end
 
   defp find_user(conn, _) do

--- a/lib/helheim_web/pagination_sanitization.ex
+++ b/lib/helheim_web/pagination_sanitization.ex
@@ -21,4 +21,17 @@ defmodule HelheimWeb.PaginationSanitization do
   def cap_total_pages(%Scrivener.Page{} = page, max_page) do
     %{page | total_pages: min(page.total_pages, max_page)}
   end
+
+  # The full list pages are capped at 100 pages to preserve performance.
+  @max_pages 100
+
+  @doc """
+  Paginates a full list page, clamping both the requested page and the
+  advertised page count to the cap.
+  """
+  def capped_paginate(query, params) do
+    query
+    |> Helheim.Repo.paginate(page: sanitized_page(params["page"], @max_pages))
+    |> cap_total_pages(@max_pages)
+  end
 end

--- a/lib/helheim_web/pagination_sanitization.ex
+++ b/lib/helheim_web/pagination_sanitization.ex
@@ -2,16 +2,25 @@ defmodule HelheimWeb.PaginationSanitization do
   def sanitized_page(nil), do: 1
   def sanitized_page(""), do: 1
   def sanitized_page(page) do
-    page = String.to_integer page
-    cond do
-      page > 1000 -> 1000
-      page < 1 -> 1
-      true -> page
+    # The page comes straight off the query string, so anything at all can turn
+    # up in it. Parsing rather than String.to_integer/1 keeps "?page=abc" - which
+    # crawlers and hand-edited urls do produce - from raising its way to a 500.
+    case Integer.parse(page) do
+      {page, ""} -> clamp_page(page)
+      _ -> 1
     end
   end
 
   def sanitized_page(page, max_page) do
     min(sanitized_page(page), max_page)
+  end
+
+  defp clamp_page(page) do
+    cond do
+      page > 1000 -> 1000
+      page < 1 -> 1
+      true -> page
+    end
   end
 
   @doc """

--- a/lib/helheim_web/router.ex
+++ b/lib/helheim_web/router.ex
@@ -130,6 +130,14 @@ defmodule HelheimWeb.Router do
       resources "/notification_subscription", NotificationSubscriptionController, singleton: true, only: [:update]
     end
     resources "/online_users", OnlineUserController, only: [:index]
+    get "/music", MusicController, :index
+    get "/music/genres/:id", MusicController, :genre
+    get "/music/decades/:decade", MusicController, :decade
+    # A glob rather than an :id, because songs - not the artists table - are the
+    # source of truth for artist identity, and a glob lets a name containing a
+    # slash ("AC/DC") travel as real path segments instead of a percent-encoded
+    # slash that a proxy might rewrite.
+    get "/music/artists/*artist_name", MusicController, :artist
     get "/songs/recent", SongController, :recent
     get "/songs/top/day", SongController, :top_day
     get "/songs/top/week", SongController, :top_week

--- a/lib/helheim_web/templates/layout/sidebar.html.eex
+++ b/lib/helheim_web/templates/layout/sidebar.html.eex
@@ -5,6 +5,12 @@
         <a class="nav-link" href="<%= page_path(@conn, :front_page)%>"><i class="fa fa-home"></i> <%= gettext("Front Page") %></a>
       </li>
       <li class="nav-item">
+        <%= link to: music_path(@conn, :index), class: "nav-link" do %>
+          <i class="fa fa-music"></i>
+          <%= gettext("Music") %>
+        <% end %>
+      </li>
+      <li class="nav-item">
         <%= link to: forum_path(@conn, :index), class: "nav-link" do %>
           <i class="fa fa-comments-o"></i>
           <%= gettext("Forums") %>

--- a/lib/helheim_web/templates/music/_artist_tile.html.eex
+++ b/lib/helheim_web/templates/music/_artist_tile.html.eex
@@ -1,0 +1,14 @@
+<%= link to: artist_page_path(@conn, @artist_name), class: "music-artist", title: @artist_name do %>
+  <%= if @artist && @artist.image_url_medium do %>
+    <img src="<%= @artist.image_url_medium %>" class="music-artist-image rounded" alt="">
+  <% else %>
+    <div class="music-artist-image music-artist-image-placeholder rounded"><i class="fa fa-user"></i></div>
+  <% end %>
+  <strong class="d-block text-truncate mt-1"><%= @artist_name %></strong>
+  <small class="d-block">
+    <%= listen_count_badge @count %>
+    <%= if @artist && @artist.country_code do %>
+      <span title="<%= @artist.country_name %>"><%= country_flag @artist.country_code %></span>
+    <% end %>
+  </small>
+<% end %>

--- a/lib/helheim_web/templates/music/artist.html.eex
+++ b/lib/helheim_web/templates/music/artist.html.eex
@@ -1,0 +1,36 @@
+<h1 class="mt-1 d-flex justify-content-between align-items-center">
+  <span><i class="fa fa-user"></i> <%= @artist_name %></span>
+  <%= link gettext("All music"), to: music_path(@conn, :index), class: "btn btn-outline-primary btn-sm mb-0" %>
+</h1>
+
+<div class="card">
+  <div class="card-block media">
+    <div class="music-artist-header-image mr-1">
+      <%= if @artist && @artist.image_url_medium do %>
+        <img src="<%= @artist.image_url_medium %>" class="music-artist-image rounded" alt="">
+      <% else %>
+        <div class="music-artist-image music-artist-image-placeholder rounded"><i class="fa fa-user"></i></div>
+      <% end %>
+    </div>
+    <div class="media-body">
+      <p class="mb-1">
+        <%= if @artist && @artist.country_code do %>
+          <span title="<%= @artist.country_name %>"><%= country_flag @artist.country_code %></span>
+          <%= @artist.country_name %><br>
+        <% end %>
+        <%= listen_count_badge @listen_count %>
+      </p>
+      <p class="mb-0">
+        <%= lastfm_link lastfm_artist_url(@artist_name), gettext("Artist on Last.fm") %>
+      </p>
+    </div>
+  </div>
+</div>
+
+<p><%= gettext "The most listened to songs by %{artist}.", artist: @artist_name %></p>
+
+<%= render HelheimWeb.SongView, "_song_list.html", conn: @conn,
+      songs: @songs,
+      count_key: :listen_count,
+      empty_message: gettext("No songs here yet..."),
+      upvoted_song_ids: @upvoted_song_ids %>

--- a/lib/helheim_web/templates/music/decade.html.eex
+++ b/lib/helheim_web/templates/music/decade.html.eex
@@ -1,0 +1,12 @@
+<h1 class="mt-1 d-flex justify-content-between align-items-center">
+  <span><i class="fa fa-clock-o"></i> <%= decade_label(@decade) %></span>
+  <%= link gettext("All music"), to: music_path(@conn, :index), class: "btn btn-outline-primary btn-sm mb-0" %>
+</h1>
+
+<p><%= gettext "The most listened to songs released in the %{decade}.", decade: decade_label(@decade) %></p>
+
+<%= render HelheimWeb.SongView, "_song_list.html", conn: @conn,
+      songs: @songs,
+      count_key: :listen_count,
+      empty_message: gettext("No songs here yet..."),
+      upvoted_song_ids: @upvoted_song_ids %>

--- a/lib/helheim_web/templates/music/genre.html.eex
+++ b/lib/helheim_web/templates/music/genre.html.eex
@@ -1,0 +1,12 @@
+<h1 class="mt-1 d-flex justify-content-between align-items-center">
+  <span><i class="fa fa-tag"></i> <%= tag_label(@tag.name) %></span>
+  <%= link gettext("All music"), to: music_path(@conn, :index), class: "btn btn-outline-primary btn-sm mb-0" %>
+</h1>
+
+<p><%= gettext "The most listened to songs tagged %{genre}.", genre: tag_label(@tag.name) %></p>
+
+<%= render HelheimWeb.SongView, "_song_list.html", conn: @conn,
+      songs: @songs,
+      count_key: :listen_count,
+      empty_message: gettext("No songs here yet..."),
+      upvoted_song_ids: @upvoted_song_ids %>

--- a/lib/helheim_web/templates/music/index.html.eex
+++ b/lib/helheim_web/templates/music/index.html.eex
@@ -1,0 +1,163 @@
+<h1 class="mt-1"><i class="fa fa-music"></i> <%= gettext "Music" %></h1>
+
+<p>
+  <%= gettext "Everything the site is listening to: the current charts, the genres and decades we keep coming back to, and the artists we play the most." %>
+</p>
+
+<p>
+  <%= link to: song_path(@conn, :recent), class: "btn btn-outline-primary btn-sm" do %>
+    <i class="fa fa-history"></i>
+    <%= gettext "Recent listens" %>
+  <% end %>
+</p>
+
+<div class="card">
+  <div class="card-block">
+    <h5 class="mb-1"><%= gettext "Helheim in numbers" %></h5>
+    <div class="music-stats">
+      <div class="callout callout-primary">
+        <h4 class="mb-0"><%= @totals.songs %></h4>
+        <small class="text-muted"><i class="fa fa-fw fa-music"></i> <%= gettext "Songs" %></small>
+      </div>
+      <div class="callout callout-info">
+        <h4 class="mb-0"><%= @totals.artists %></h4>
+        <small class="text-muted"><i class="fa fa-fw fa-user"></i> <%= gettext "Artists" %></small>
+      </div>
+      <div class="callout callout-success">
+        <h4 class="mb-0"><%= @totals.listens %></h4>
+        <small class="text-muted"><i class="fa fa-fw fa-headphones"></i> <%= gettext "Listens" %></small>
+      </div>
+      <div class="callout callout-warning">
+        <h4 class="mb-0"><%= @totals.upvotes %></h4>
+        <small class="text-muted"><i class="fa fa-fw fa-fire"></i> <%= gettext "Upvotes" %></small>
+      </div>
+      <div class="callout callout-danger">
+        <h4 class="mb-0"><%= @totals.listeners %></h4>
+        <small class="text-muted"><i class="fa fa-fw fa-users"></i> <%= gettext "Listeners" %></small>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row music-charts">
+  <div class="col-12 col-md-6">
+    <div class="card">
+      <div class="card-block">
+        <h5 class="mb-1"><i class="fa fa-fw fa-tags"></i> <%= gettext "Genres" %></h5>
+        <%= if Enum.empty?(@top_genres) do %>
+          <p class="text-muted mb-0"><%= gettext "No songs have been tagged with a genre yet..." %></p>
+        <% end %>
+        <% largest_genre = largest_count(@top_genres) %>
+        <%= for {tag, count} <- @top_genres do %>
+          <%= link to: music_path(@conn, :genre, tag), class: "music-bar", title: tag_label(tag.name) do %>
+            <span class="music-bar-label">
+              <span class="music-bar-name text-truncate"><i class="fa fa-fw fa-tag"></i> <%= tag_label(tag.name) %></span>
+              <%= listen_count_badge count %>
+            </span>
+            <div class="progress progress-xs">
+              <div class="progress-bar" style="width: <%= bar_percent(count, largest_genre) %>%" aria-hidden="true"></div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-12 col-md-6">
+    <div class="card">
+      <div class="card-block">
+        <h5 class="mb-1"><i class="fa fa-fw fa-clock-o"></i> <%= gettext "Decades" %></h5>
+        <%= if Enum.empty?(@listens_per_decade) do %>
+          <p class="text-muted mb-0"><%= gettext "No songs with a known release year yet..." %></p>
+        <% end %>
+        <% largest_decade = largest_count(@listens_per_decade) %>
+        <div class="music-decades">
+          <%= for {decade, count} <- @listens_per_decade do %>
+            <%= link to: music_path(@conn, :decade, decade), class: "music-decade", title: decade_label(decade) do %>
+              <span class="music-decade-count"><%= count %></span>
+              <span class="music-decade-track">
+                <span class="music-decade-bar" style="height: <%= bar_percent(count, largest_decade) %>%"></span>
+              </span>
+              <span class="music-decade-label"><%= decade_short_label(decade) %></span>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-block">
+    <h5 class="mb-1"><i class="fa fa-fw fa-users"></i> <%= gettext "Top artists" %></h5>
+    <%= if Enum.empty?(@top_artists) do %>
+      <p class="text-muted mb-0"><%= gettext "No listens have been tracked yet..." %></p>
+    <% end %>
+
+    <div class="row">
+      <%= for {artist_name, count, artist} <- Enum.take(@top_artists, 3) do %>
+        <div class="col-4">
+          <%= render "_artist_tile.html", conn: @conn, artist_name: artist_name, count: count, artist: artist %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="row">
+      <%= for {{artist_name, count, artist}, rank} <- @top_artists |> Enum.drop(3) |> Enum.with_index(4) do %>
+        <div class="col-12 col-md-6">
+          <div class="media mb-1">
+            <span class="music-rank"><%= rank %></span>
+            <%= render HelheimWeb.SongView, "_cover.html",
+                  href: artist_page_path(@conn, artist_name),
+                  image_url: artist && artist.image_url_small,
+                  icon: "fa-user" %>
+            <div class="media-body">
+              <%= link artist_name, to: artist_page_path(@conn, artist_name) %>
+              <%= if artist && artist.country_code do %>
+                <span title="<%= artist.country_name %>"><%= country_flag artist.country_code %></span>
+              <% end %>
+              <br>
+              <%= listen_count_badge count %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="card-group">
+  <%= render HelheimWeb.SongView, "_chart_card.html", conn: @conn,
+        title: gettext("Top songs, past 24 hours"),
+        show_all_path: song_path(@conn, :top_day),
+        songs: @top_songs_day,
+        count_key: :listen_count,
+        empty_message: gettext("No songs have been listened to in this period yet..."),
+        upvoted_song_ids: @upvoted_song_ids %>
+
+  <%= render HelheimWeb.SongView, "_chart_card.html", conn: @conn,
+        title: gettext("Top songs, past 7 days"),
+        show_all_path: song_path(@conn, :top_week),
+        songs: @top_songs_week,
+        count_key: :listen_count,
+        empty_message: gettext("No songs have been listened to in this period yet..."),
+        upvoted_song_ids: @upvoted_song_ids %>
+</div>
+
+<div class="card-group">
+  <%= render HelheimWeb.SongView, "_chart_card.html", conn: @conn,
+        title: gettext("Most upvoted songs, past 24 hours"),
+        show_all_path: song_path(@conn, :top_upvoted_day),
+        songs: @top_upvoted_day,
+        count_key: :upvote_count,
+        empty_message: gettext("No songs have been upvoted in this period yet..."),
+        upvoted_song_ids: @upvoted_song_ids %>
+
+  <%= render HelheimWeb.SongView, "_chart_card.html", conn: @conn,
+        title: gettext("Most upvoted songs, past 7 days"),
+        show_all_path: song_path(@conn, :top_upvoted_week),
+        songs: @top_upvoted_week,
+        count_key: :upvote_count,
+        empty_message: gettext("No songs have been upvoted in this period yet..."),
+        upvoted_song_ids: @upvoted_song_ids %>
+</div>

--- a/lib/helheim_web/templates/page/front_page.html.eex
+++ b/lib/helheim_web/templates/page/front_page.html.eex
@@ -4,20 +4,8 @@
       <%= gettext "Recently logged in users" %>
       <%= link gettext("Show All"), to: public_profile_path(@conn, :index), class: "btn btn-outline-primary btn-sm mb-0" %>
     </h5>
-    <div class="avatar-list">
-      <%= for user <- @newest_users do %>
-        <a href="<%= public_profile_path(@conn, :show, user.id) %>">
-          <img
-            src="<%= HelheimWeb.Avatar.url({user.avatar, user}, :tiny) %>"
-            class="rounded"
-            alt="<%= user.username %>"
-            data-toggle="tooltip"
-            data-placement="bottom"
-            title="<%= user.username %>"
-          >
-        </a>
-      <% end %>
-    </div>
+    <%= render HelheimWeb.SharedView, "_avatar_list.html", conn: @conn,
+          entries: Enum.map(@newest_users, &{&1, &1.username}) %>
   </div>
 </div>
 
@@ -77,54 +65,22 @@
 </div>
 
 <%= if length(@recent_song_listens) > 0 do %>
-  <div class="card-group mt-1">
-    <div class="card">
-      <div class="card-block">
-        <h5 class="mb-1 d-flex justify-content-between">
-          <%= gettext "Recent listens" %>
-          <%= link gettext("Show All"), to: song_path(@conn, :recent), class: "btn btn-outline-primary btn-sm mb-0" %>
-        </h5>
-        <%= for listen <- @recent_song_listens do %>
-          <%= render HelheimWeb.SongView, "_listen.html", conn: @conn, listen: listen, upvoted_song_ids: @upvoted_song_ids %>
+  <div class="card mt-1">
+    <div class="card-block">
+      <h5 class="mb-1 d-flex justify-content-between">
+        <%= gettext "Recent listens" %>
+        <%= link gettext("Show All"), to: music_path(@conn, :index), class: "btn btn-outline-primary btn-sm mb-0" %>
+      </h5>
+      <div class="row">
+        <%= for {listens, hidden_class} <- recent_listen_columns(@recent_song_listens) do %>
+          <div class="col-12 col-md-6 col-lg-4 <%= hidden_class %>">
+            <%= for listen <- listens do %>
+              <%= render HelheimWeb.SongView, "_listen.html", conn: @conn, listen: listen, upvoted_song_ids: @upvoted_song_ids %>
+            <% end %>
+          </div>
         <% end %>
       </div>
     </div>
-
-    <%= render HelheimWeb.SongView, "_chart_card.html", conn: @conn,
-          title: gettext("Top songs, past 24 hours"),
-          show_all_path: song_path(@conn, :top_day),
-          songs: @top_songs_day,
-          count_key: :listen_count,
-          empty_message: gettext("No songs have been listened to in this period yet..."),
-          upvoted_song_ids: @upvoted_song_ids %>
-
-    <%= render HelheimWeb.SongView, "_chart_card.html", conn: @conn,
-          title: gettext("Top songs, past 7 days"),
-          show_all_path: song_path(@conn, :top_week),
-          songs: @top_songs_week,
-          count_key: :listen_count,
-          empty_message: gettext("No songs have been listened to in this period yet..."),
-          upvoted_song_ids: @upvoted_song_ids %>
-  </div>
-<% end %>
-
-<%= if length(@top_upvoted_day) + length(@top_upvoted_week) > 0 do %>
-  <div class="card-group mt-1">
-    <%= render HelheimWeb.SongView, "_chart_card.html", conn: @conn,
-          title: gettext("Most upvoted songs, past 24 hours"),
-          show_all_path: song_path(@conn, :top_upvoted_day),
-          songs: @top_upvoted_day,
-          count_key: :upvote_count,
-          empty_message: gettext("No songs have been upvoted in this period yet..."),
-          upvoted_song_ids: @upvoted_song_ids %>
-
-    <%= render HelheimWeb.SongView, "_chart_card.html", conn: @conn,
-          title: gettext("Most upvoted songs, past 7 days"),
-          show_all_path: song_path(@conn, :top_upvoted_week),
-          songs: @top_upvoted_week,
-          count_key: :upvote_count,
-          empty_message: gettext("No songs have been upvoted in this period yet..."),
-          upvoted_song_ids: @upvoted_song_ids %>
   </div>
 <% end %>
 

--- a/lib/helheim_web/templates/shared/_avatar_list.html.eex
+++ b/lib/helheim_web/templates/shared/_avatar_list.html.eex
@@ -1,0 +1,25 @@
+<%!--
+  A compact grid of linked profile photos.
+
+  Required assigns:
+    conn    - the connection
+    entries - list of {%Helheim.User{}, tooltip} tuples, in display order
+
+  Optional assigns:
+    class - extra classes for the container, e.g. "avatar-list-full" to show
+            every avatar instead of clipping the grid to a few rows
+--%>
+<div class="avatar-list <%= assigns[:class] %>">
+  <%= for {user, tooltip} <- @entries do %>
+    <a href="<%= public_profile_path(@conn, :show, user) %>">
+      <img
+        src="<%= HelheimWeb.Avatar.url({user.avatar, user}, :tiny) %>"
+        class="rounded"
+        alt="<%= user.username %>"
+        data-toggle="tooltip"
+        data-placement="bottom"
+        title="<%= tooltip %>"
+      >
+    </a>
+  <% end %>
+</div>

--- a/lib/helheim_web/templates/song/_song_grid_item.html.eex
+++ b/lib/helheim_web/templates/song/_song_grid_item.html.eex
@@ -1,0 +1,51 @@
+<%!--
+  One tile in a `.song-grid`: a large cover over the song's details.
+
+  Required assigns:
+    conn, song, upvoted_song_ids
+
+  Optional assigns:
+    listen_count, upvote_count - extra badges, as in _song.html
+    listen                     - the SongListen this tile came from, adding who
+                                 played it and when
+    show_username              - pass false to leave the listener out, for a
+                                 page that is already about one person
+--%>
+<div class="song-grid-item">
+  <div class="song-cover-frame">
+    <a href="<%= song_path(@conn, :show, @song) %>">
+      <%= if grid_cover_url(@song) do %>
+        <img src="<%= grid_cover_url(@song) %>" class="song-grid-cover rounded" alt="">
+      <% else %>
+        <div class="song-grid-cover song-grid-cover-placeholder rounded"><i class="fa fa-music"></i></div>
+      <% end %>
+    </a>
+    <%= preview_button @conn, @song %>
+  </div>
+  <div class="song-grid-body">
+    <strong class="d-block text-truncate" title="<%= @song.title %>">
+      <%= link @song.title, to: song_path(@conn, :show, @song) %>
+    </strong>
+    <small class="d-block text-truncate" title="<%= @song.artist_name %>">
+      <%= link @song.artist_name, to: artist_page_path(@conn, @song.artist_name), class: "song-grid-artist" %>
+    </small>
+    <%= if assigns[:listen] do %>
+      <small class="d-block text-truncate">
+        <%= if assigns[:show_username] != false do %>
+          <%= username @listen.user, true %>,
+        <% end %>
+        <%= time_ago_in_words @listen.played_at %>
+      </small>
+    <% end %>
+    <div class="song-grid-badges">
+      <%= comment_count_badge @song %>
+      <%= if assigns[:listen_count] do %>
+        <%= listen_count_badge @listen_count %>
+      <% end %>
+      <%= if assigns[:upvote_count] do %>
+        <%= upvote_count_badge @upvote_count %>
+      <% end %>
+      <%= upvote_toggle @conn, @song, assigns %>
+    </div>
+  </div>
+</div>

--- a/lib/helheim_web/templates/song/_song_grid_item.html.eex
+++ b/lib/helheim_web/templates/song/_song_grid_item.html.eex
@@ -13,7 +13,9 @@
 --%>
 <div class="song-grid-item">
   <div class="song-cover-frame">
-    <a href="<%= song_path(@conn, :show, @song) %>">
+    <%!-- The cover is decorative, so the link needs a name of its own rather
+          than reading as an unnamed link to a screen reader. --%>
+    <a href="<%= song_path(@conn, :show, @song) %>" aria-label="<%= @song.title %>">
       <%= if grid_cover_url(@song) do %>
         <img src="<%= grid_cover_url(@song) %>" class="song-grid-cover rounded" alt="">
       <% else %>

--- a/lib/helheim_web/templates/song/_song_list.html.eex
+++ b/lib/helheim_web/templates/song/_song_list.html.eex
@@ -1,0 +1,13 @@
+<div class="card">
+  <div class="card-block">
+    <%= if Enum.empty?(@songs) do %>
+      <p class="text-muted mb-0"><%= @empty_message %></p>
+    <% end %>
+    <div class="song-grid">
+      <%= for {song, count} <- @songs do %>
+        <%= render "_song_grid_item.html", [{@count_key, count}, conn: @conn, song: song, upvoted_song_ids: @upvoted_song_ids] %>
+      <% end %>
+    </div>
+    <%= pagination_links @conn, @songs %>
+  </div>
+</div>

--- a/lib/helheim_web/templates/song/recent.html.eex
+++ b/lib/helheim_web/templates/song/recent.html.eex
@@ -5,9 +5,11 @@
     <%= if Enum.empty?(@listens) do %>
       <p class="text-muted mb-0"><%= gettext "No listens have been tracked yet..." %></p>
     <% end %>
-    <%= for listen <- @listens do %>
-      <%= render "_listen.html", conn: @conn, listen: listen, upvoted_song_ids: @upvoted_song_ids %>
-    <% end %>
+    <div class="song-grid">
+      <%= for listen <- @listens do %>
+        <%= render "_song_grid_item.html", conn: @conn, song: listen.song, listen: listen, upvoted_song_ids: @upvoted_song_ids %>
+      <% end %>
+    </div>
     <%= pagination_links @conn, @listens %>
   </div>
 </div>

--- a/lib/helheim_web/templates/song/show.html.eex
+++ b/lib/helheim_web/templates/song/show.html.eex
@@ -12,7 +12,7 @@
         <table class="table table-sm">
           <tr>
             <th><%= gettext "Artist" %></th>
-            <td><%= @song.artist_name %></td>
+            <td><%= link @song.artist_name, to: artist_page_path(@conn, @song.artist_name) %></td>
           </tr>
           <%= if @song.album_name do %>
             <tr>
@@ -29,7 +29,7 @@
           <%= if genre_tag = List.first(@song.song_tags) do %>
             <tr>
               <th><%= gettext "Genre" %></th>
-              <td><%= genre_tag.tag.name %></td>
+              <td><%= tag_label(genre_tag.tag.name) %></td>
             </tr>
           <% end %>
           <tr>
@@ -44,7 +44,7 @@
         <%= if length(@song.song_tags) > 0 do %>
           <p>
             <%= for song_tag <- @song.song_tags do %>
-              <span class="badge badge-default"><i class="fa fa-fw fa-tag"></i> <%= song_tag.tag.name %></span>
+              <span class="badge badge-default"><i class="fa fa-fw fa-tag"></i> <%= tag_label(song_tag.tag.name) %></span>
             <% end %>
           </p>
         <% end %>
@@ -73,14 +73,25 @@
     <div class="card">
       <div class="card-block">
         <h5 class="mb-1"><%= gettext "Recent listeners" %></h5>
-        <%= if length(@recent_listens) == 0 do %>
+        <%= if Enum.empty?(@recent_listens) do %>
           <p class="text-muted mb-0"><%= gettext "No one has listened to this song yet..." %></p>
+        <% else %>
+          <%= render HelheimWeb.SharedView, "_avatar_list.html", conn: @conn,
+                class: "avatar-list-full",
+                entries: Enum.map(@recent_listens, &{&1.user, avatar_tooltip(&1.user, &1.played_at)}) %>
         <% end %>
-        <%= for listen <- @recent_listens do %>
-          <div class="mb-1">
-            <%= avatar_with_username listen.user, true %>
-            <small class="text-muted"><%= time_ago_in_words listen.played_at %></small>
-          </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-block">
+        <h5 class="mb-1"><%= gettext "Upvoted by" %></h5>
+        <%= if Enum.empty?(@recent_upvotes) do %>
+          <p class="text-muted mb-0"><%= gettext "No one has upvoted this song yet..." %></p>
+        <% else %>
+          <%= render HelheimWeb.SharedView, "_avatar_list.html", conn: @conn,
+                class: "avatar-list-full",
+                entries: Enum.map(@recent_upvotes, &{&1.user, avatar_tooltip(&1.user, &1.inserted_at)}) %>
         <% end %>
       </div>
     </div>

--- a/lib/helheim_web/templates/song/top.html.eex
+++ b/lib/helheim_web/templates/song/top.html.eex
@@ -1,13 +1,4 @@
 <h1 class="mt-1"><%= @title %></h1>
 
-<div class="card">
-  <div class="card-block">
-    <%= if Enum.empty?(@songs) do %>
-      <p class="text-muted mb-0"><%= @empty_message %></p>
-    <% end %>
-    <%= for {song, count} <- @songs do %>
-      <%= render "_song.html", [{@count_key, count}, conn: @conn, song: song, upvoted_song_ids: @upvoted_song_ids] %>
-    <% end %>
-    <%= pagination_links @conn, @songs %>
-  </div>
-</div>
+<%= render "_song_list.html", conn: @conn, songs: @songs, count_key: @count_key,
+      empty_message: @empty_message, upvoted_song_ids: @upvoted_song_ids %>

--- a/lib/helheim_web/templates/song_listen/index.html.eex
+++ b/lib/helheim_web/templates/song_listen/index.html.eex
@@ -48,9 +48,11 @@
     <%= if Enum.empty?(@listens) do %>
       <p class="text-muted mb-0"><%= gettext "No listens have been tracked yet..." %></p>
     <% end %>
-    <%= for listen <- @listens do %>
-      <%= render HelheimWeb.SongView, "_listen.html", conn: @conn, listen: listen, show_username: false, upvoted_song_ids: @upvoted_song_ids %>
-    <% end %>
+    <div class="song-grid">
+      <%= for listen <- @listens do %>
+        <%= render HelheimWeb.SongView, "_song_grid_item.html", conn: @conn, song: listen.song, listen: listen, show_username: false, upvoted_song_ids: @upvoted_song_ids %>
+      <% end %>
+    </div>
     <%= pagination_links @conn, @listens %>
   </div>
 </div>

--- a/lib/helheim_web/views/music_helpers.ex
+++ b/lib/helheim_web/views/music_helpers.ex
@@ -1,0 +1,34 @@
+defmodule HelheimWeb.MusicHelpers do
+  @moduledoc """
+  Links into, and labels for, the music pages.
+
+  Artist pages are keyed by name, not by id, so the route is a glob. Splitting
+  the name on "/" turns AC/DC into two real path segments, which
+  `HelheimWeb.MusicController` rejoins - and Phoenix glob helpers take a list
+  of segments, so handing them a bare name would raise rather than build a
+  path. Wrapped here so no template has to remember either detail.
+  """
+  import HelheimWeb.Router.Helpers
+
+  def artist_page_path(conn, artist_name) do
+    music_path(conn, :artist, String.split(artist_name, "/"))
+  end
+
+  @doc """
+  A tag name as a display label. Tags come from Last.fm in whatever casing the
+  people tagging used - almost always all lower case - so the first letter of
+  each word is upper cased for display. A song's genre is just its first tag, so
+  this covers every genre label too.
+
+  Only the leading letter of each word is touched and the rest is left exactly as
+  stored, which keeps an acronym someone typed properly ("NWOBHM") intact where
+  capitalizing whole words would flatten it to "Nwobhm". A word starts after
+  anything that is not a letter or a digit, so hyphens and ampersands split too
+  ("post-punk" -> "Post-Punk", "r&b" -> "R&B"), while a digit does not
+  ("80s" stays "80s").
+  """
+  def tag_label(nil), do: nil
+  def tag_label(name) do
+    String.replace(name, ~r/(?<![\p{L}\p{N}])\p{Ll}/u, &String.upcase/1)
+  end
+end

--- a/lib/helheim_web/views/music_view.ex
+++ b/lib/helheim_web/views/music_view.ex
@@ -1,0 +1,42 @@
+defmodule HelheimWeb.MusicView do
+  use HelheimWeb, :view
+
+  # The music page leans on the song badges and Last.fm links. `only:` is
+  # required - a bare import would also pull in SongView's render/2 and clash
+  # with this view's own.
+  import HelheimWeb.SongView,
+    only: [country_flag: 1, listen_count_badge: 1, lastfm_link: 2, lastfm_artist_url: 1]
+
+  @doc """
+  A decade as a label, e.g. `1990` -> "1990s". Translated, since Danish forms it
+  differently ("1990'erne").
+  """
+  def decade_label(decade), do: gettext("%{decade}s", decade: decade)
+
+  @doc """
+  The abbreviated label under a decade bar, e.g. `1990` -> "90s". The full label
+  is on the bar's title attribute.
+  """
+  def decade_short_label(decade) do
+    gettext("%{short}s", short: decade |> Integer.to_string() |> String.slice(-2, 2))
+  end
+
+  @doc """
+  The biggest count in a chart, used as the 100% reference for its bars. Handles
+  both the `{key, count}` rows and the `{name, count, artist}` artist rows, and
+  cannot just read the head of the list: decades arrive in chronological order,
+  not ordered by count.
+  """
+  def largest_count([]), do: 0
+  def largest_count(rows), do: rows |> Enum.map(&row_count/1) |> Enum.max()
+
+  @doc """
+  A bar's size as a percentage of the biggest value in the same chart, floored
+  at 2% so that the smallest entry is still a visible target.
+  """
+  def bar_percent(_count, largest) when largest in [nil, 0], do: 0
+  def bar_percent(count, largest), do: max(round(count / largest * 100), 2)
+
+  defp row_count({_key, count}), do: count
+  defp row_count({_name, count, _artist}), do: count
+end

--- a/lib/helheim_web/views/page_view.ex
+++ b/lib/helheim_web/views/page_view.ex
@@ -1,3 +1,16 @@
 defmodule HelheimWeb.PageView do
   use HelheimWeb, :view
+
+  @doc """
+  Splits the recent listens into up to three columns of five, each paired with
+  the class that hides it on screens too narrow to fit it: one column below md,
+  two below lg, three from lg up. Fewer than 15 listens simply yields fewer
+  columns, and `Enum.zip/2` drops the classes it no longer needs, so an empty
+  column is never rendered.
+  """
+  def recent_listen_columns(listens) do
+    listens
+    |> Enum.chunk_every(5)
+    |> Enum.zip(["", "hidden-sm-down", "hidden-md-down"])
+  end
 end

--- a/lib/helheim_web/views/shared_view.ex
+++ b/lib/helheim_web/views/shared_view.ex
@@ -1,0 +1,6 @@
+defmodule HelheimWeb.SharedView do
+  @moduledoc """
+  Templates shared across views that have no controller of their own.
+  """
+  use HelheimWeb, :view
+end

--- a/lib/helheim_web/views/song_view.ex
+++ b/lib/helheim_web/views/song_view.ex
@@ -6,6 +6,15 @@ defmodule HelheimWeb.SongView do
   end
 
   @doc """
+  The best cover to show at grid size. `cover_image_url` is 300x300, which is
+  plenty for a tile and lighter than the 500x500 detail image; the 64px
+  thumbnail is a last resort, since scaling it up to a tile looks soft.
+  """
+  def grid_cover_url(song) do
+    song.cover_image_url || song.cover_image_url_large || song.cover_image_url_small
+  end
+
+  @doc """
   Renders an ISO 3166-1 alpha-2 country code as its flag emoji via the
   regional indicator codepoints - no image assets needed. MusicBrainz's
   user-assigned region codes (XW worldwide, XE Europe, ...) have no flag
@@ -45,6 +54,17 @@ defmodule HelheimWeb.SongView do
       aria_label: gettext("Play preview"),
       data: [preview_url: song_preview_path(conn, :preview, song)]
     )
+  end
+
+  @doc """
+  Tooltip text for an avatar in a listener or upvoter grid: the plain username
+  plus how long ago the listen or vote happened. Deliberately not `username/1` -
+  that returns markup (badges, links) which cannot live inside a title
+  attribute, and `simple: true` keeps `time_ago_in_words/2` from wrapping its
+  text in a span for the same reason.
+  """
+  def avatar_tooltip(user, timestamp) do
+    "#{user.username} - #{time_ago_in_words(timestamp, simple: true)}"
   end
 
   def listen_count_badge(count) do

--- a/priv/gettext/da/LC_MESSAGES/default.po
+++ b/priv/gettext/da/LC_MESSAGES/default.po
@@ -61,7 +61,7 @@ msgstr "Opret Profil"
 
 #: lib/helheim_web/templates/account/edit.html.eex:24
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:13
-#: lib/helheim_web/templates/admin/user/_users.html.eex:14
+#: lib/helheim_web/templates/admin/user/_users.html.eex:15
 #: lib/helheim_web/templates/admin/user/index.html.eex:26
 #: lib/helheim_web/templates/confirmation/new.html.eex:10
 #: lib/helheim_web/templates/password_reset/new.html.eex:10
@@ -83,7 +83,7 @@ msgstr "Hvis du ikke har modtaget din aktiveringsmail, kan du indtaste din e-mai
 
 #: lib/helheim_web/templates/account/edit.html.eex:14
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:10
-#: lib/helheim_web/templates/admin/user/_users.html.eex:11
+#: lib/helheim_web/templates/admin/user/_users.html.eex:12
 #: lib/helheim_web/templates/admin/user/index.html.eex:21
 #: lib/helheim_web/templates/registration/new.html.eex:23
 #, elixir-autogen
@@ -123,7 +123,7 @@ msgid "Sign In"
 msgstr "Log ind"
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:7
-#: lib/helheim_web/templates/admin/user/_users.html.eex:8
+#: lib/helheim_web/templates/admin/user/_users.html.eex:9
 #: lib/helheim_web/templates/admin/user/index.html.eex:16
 #: lib/helheim_web/templates/profile/index.html.eex:15
 #: lib/helheim_web/templates/registration/new.html.eex:9
@@ -473,25 +473,25 @@ msgstr "Opdatér Profil"
 msgid "Remember me"
 msgstr "Husk mig i 30 dage"
 
-#: lib/helheim_web/templates/page/front_page.html.eex:28
+#: lib/helheim_web/templates/page/front_page.html.eex:16
 #: lib/helheim_web/templates/profile/show.html.eex:76
 #, elixir-autogen
 msgid "Newest Blogs"
 msgstr "Nyeste Blogs"
 
-#: lib/helheim_web/templates/page/front_page.html.eex:40
+#: lib/helheim_web/templates/page/front_page.html.eex:28
 #: lib/helheim_web/templates/profile/show.html.eex:87
 #, elixir-autogen
 msgid "Newest Forum Posts"
 msgstr "Nyeste Forumindlæg"
 
-#: lib/helheim_web/templates/page/front_page.html.eex:135
+#: lib/helheim_web/templates/page/front_page.html.eex:91
 #: lib/helheim_web/templates/profile/show.html.eex:111
 #, elixir-autogen
 msgid "Newest Photos"
 msgstr "Nyeste Fotos"
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:63
+#: lib/helheim_web/templates/layout/sidebar.html.eex:69
 #, elixir-autogen
 msgid "Your Profile"
 msgstr "Din Profil"
@@ -515,14 +515,14 @@ msgstr "Gem Blog"
 
 #: lib/helheim_web/templates/blog_post/edit.html.eex:2
 #: lib/helheim_web/templates/blog_post/new.html.eex:2
-#: lib/helheim_web/templates/layout/sidebar.html.eex:84
+#: lib/helheim_web/templates/layout/sidebar.html.eex:90
 #, elixir-autogen
 msgid "Your Blog Posts"
 msgstr "Dine Blogs"
 
 #: lib/helheim_web/templates/admin/forum_category/index.html.eex:13
 #: lib/helheim_web/templates/admin/forum_category/index.html.eex:39
-#: lib/helheim_web/templates/admin/term/index.html.eex:35
+#: lib/helheim_web/templates/admin/term/index.html.eex:36
 #: lib/helheim_web/templates/blog_post/show.html.eex:30
 #: lib/helheim_web/templates/friendship/_my_active_friendships.html.eex:23
 #: lib/helheim_web/templates/friendship/_my_pending_friendships.html.eex:28
@@ -575,8 +575,8 @@ msgstr "Redigér Blog"
 
 #: lib/helheim_web/templates/admin/forum/form.html.eex:4
 #: lib/helheim_web/templates/admin/forum_category/form.html.eex:4
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:8
-#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:9
+#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:9
 #: lib/helheim_web/templates/blog_post/form.html.eex:4
 #: lib/helheim_web/templates/calendar_event/_form.html.eex:4
 #: lib/helheim_web/templates/forum_topic/form.html.eex:4
@@ -592,7 +592,7 @@ msgstr "Titel"
 msgid "Comment created successfully"
 msgstr "Din kommentar er tilføjet!"
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:68
+#: lib/helheim_web/templates/layout/sidebar.html.eex:74
 #: lib/helheim_web/views/comment_view.ex:16
 #, elixir-autogen
 msgid "Guest Book"
@@ -610,11 +610,11 @@ msgstr "Tilføj Kommentar"
 
 #: lib/helheim_web/templates/comment/comments.html.eex:9
 #: lib/helheim_web/templates/page/front_page.html.eex:5
+#: lib/helheim_web/templates/page/front_page.html.eex:17
 #: lib/helheim_web/templates/page/front_page.html.eex:29
-#: lib/helheim_web/templates/page/front_page.html.eex:41
-#: lib/helheim_web/templates/page/front_page.html.eex:56
-#: lib/helheim_web/templates/page/front_page.html.eex:85
-#: lib/helheim_web/templates/page/front_page.html.eex:136
+#: lib/helheim_web/templates/page/front_page.html.eex:44
+#: lib/helheim_web/templates/page/front_page.html.eex:72
+#: lib/helheim_web/templates/page/front_page.html.eex:92
 #: lib/helheim_web/templates/profile/show.html.eex:81
 #: lib/helheim_web/templates/profile/show.html.eex:104
 #: lib/helheim_web/templates/profile/show.html.eex:117
@@ -676,7 +676,7 @@ msgid_plural "You have %{count} notifications"
 msgstr[0] "Du har %{count} notifikation"
 msgstr[1] "Du har %{count} notifikationer"
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:80
+#: lib/helheim_web/templates/layout/sidebar.html.eex:86
 #: lib/helheim_web/templates/private_conversation/index.html.eex:1
 #, elixir-autogen
 msgid "Private Messages"
@@ -841,7 +841,7 @@ msgstr "Upload billeder"
 msgid "Uploaded"
 msgstr "Uploadet"
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:89
+#: lib/helheim_web/templates/layout/sidebar.html.eex:95
 #, elixir-autogen
 msgid "Your Photo Albums"
 msgstr "Dine Fotoalbums"
@@ -866,7 +866,7 @@ msgstr "Du har brugt %{used_space} ud af maksimum %{max_space} fordelt over alle
 msgid "Administration"
 msgstr "Administration"
 
-#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:9
 #: lib/helheim_web/templates/blog_post/form.html.eex:12
 #: lib/helheim_web/templates/forum_reply/form.html.eex:12
 #: lib/helheim_web/templates/forum_topic/form.html.eex:12
@@ -953,7 +953,7 @@ msgstr "Forummet blev opdateret!"
 #: lib/helheim_web/templates/forum_topic/edit.html.eex:2
 #: lib/helheim_web/templates/forum_topic/new.html.eex:2
 #: lib/helheim_web/templates/forum_topic/show.html.eex:2
-#: lib/helheim_web/templates/layout/sidebar.html.eex:10
+#: lib/helheim_web/templates/layout/sidebar.html.eex:16
 #, elixir-autogen
 msgid "Forums"
 msgstr "Forum"
@@ -1028,7 +1028,7 @@ msgstr "Gem forum kategori"
 msgid "Submit new reply"
 msgstr "Send nyt svar"
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:60
+#: lib/helheim_web/templates/layout/sidebar.html.eex:66
 #, elixir-autogen
 msgid "You"
 msgstr "Dig"
@@ -1138,7 +1138,7 @@ msgstr "Redigér Betingelser"
 msgid "However, that doesn't meant that you should be an dick, so behave!"
 msgstr "Det betyder dog ikke at du har lov til at være et røvhul, så opfør dig pænt!"
 
-#: lib/helheim_web/templates/admin/term/index.html.eex:15
+#: lib/helheim_web/templates/admin/term/index.html.eex:16
 #: lib/helheim_web/templates/mod/calendar_event/index.html.eex:13
 #, elixir-autogen
 msgid "Inserted at"
@@ -1151,7 +1151,7 @@ msgid "New Terms"
 msgstr "Opret Betingelser"
 
 #: lib/helheim_web/templates/admin/term/form.html.eex:14
-#: lib/helheim_web/templates/admin/term/index.html.eex:17
+#: lib/helheim_web/templates/admin/term/index.html.eex:18
 #, elixir-autogen
 msgid "Published?"
 msgstr "Udgivet?"
@@ -1201,7 +1201,7 @@ msgstr "Betingelserne blev opdateret!"
 msgid "There doesn't seem to be any terms or rules written yet..."
 msgstr "Det lader ikke til at der nogle betingelser skrevet ned endnu…"
 
-#: lib/helheim_web/templates/admin/term/index.html.eex:16
+#: lib/helheim_web/templates/admin/term/index.html.eex:17
 #, elixir-autogen
 msgid "Updated at"
 msgstr "Opdateret"
@@ -1264,7 +1264,7 @@ msgid "Comments"
 msgstr "Kommentarer"
 
 #: lib/helheim_web/templates/help/verification.html.eex:2
-#: lib/helheim_web/templates/layout/sidebar.html.eex:36
+#: lib/helheim_web/templates/layout/sidebar.html.eex:42
 #: lib/helheim_web/templates/page/staff.html.eex:2
 #, elixir-autogen
 msgid "Help"
@@ -1357,7 +1357,7 @@ msgstr "Vi viser aldrig din fødselsdato til andre brugere, kun din alder. Det e
 msgid "Photos"
 msgstr "Billeder"
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:16
+#: lib/helheim_web/templates/layout/sidebar.html.eex:22
 #: lib/helheim_web/templates/profile/index.html.eex:2
 #, elixir-autogen
 msgid "Profiles"
@@ -1883,7 +1883,7 @@ msgid "Add to Contacts"
 msgstr "Føj til kontaktliste"
 
 #: lib/helheim_web/templates/friendship/index.html.eex:3
-#: lib/helheim_web/templates/layout/sidebar.html.eex:74
+#: lib/helheim_web/templates/layout/sidebar.html.eex:80
 #, elixir-autogen
 msgid "Contact List"
 msgstr "Kontaktliste"
@@ -1970,7 +1970,7 @@ msgstr "Kommentarer er deaktiveret på denne blog"
 msgid "Hide comments?"
 msgstr "Skjul kommentarer?"
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:42
+#: lib/helheim_web/templates/layout/sidebar.html.eex:48
 #, elixir-autogen
 msgid "Terms and Rules"
 msgstr "Betingelser og Regler"
@@ -2006,7 +2006,7 @@ msgid "Blog Post"
 msgstr "Blog"
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:19
-#: lib/helheim_web/templates/admin/user/_users.html.eex:20
+#: lib/helheim_web/templates/admin/user/_users.html.eex:21
 #, elixir-autogen
 msgid "Confirmed at"
 msgstr "Bekræftelsesdato"
@@ -2017,17 +2017,17 @@ msgid "Confirmed?"
 msgstr "Bekræftet?"
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:16
-#: lib/helheim_web/templates/admin/user/_users.html.eex:17
+#: lib/helheim_web/templates/admin/user/_users.html.eex:18
 #, elixir-autogen
 msgid "Created at"
 msgstr "Oprettelsesdato"
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:4
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:7
-#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:7
-#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:7
-#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:7
-#: lib/helheim_web/templates/admin/user/_users.html.eex:5
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:8
+#: lib/helheim_web/templates/admin/user/_users.html.eex:6
 #, elixir-autogen
 msgid "ID"
 msgstr "ID"
@@ -2042,12 +2042,12 @@ msgstr "IP Adresse"
 msgid "Login Details"
 msgstr "Logindetaljer"
 
-#: lib/helheim_web/templates/admin/user/_blocks.html.eex:32
+#: lib/helheim_web/templates/admin/user/_blocks.html.eex:34
 #: lib/helheim_web/templates/admin/user/_potential_alt_accounts.html.eex:7
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:38
-#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:29
-#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:32
-#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:32
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:40
+#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:31
+#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:34
+#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:34
 #: lib/helheim_web/templates/admin/user/_recent_photos.html.eex:22
 #, elixir-autogen
 msgid "None found"
@@ -2106,17 +2106,17 @@ msgid "Users"
 msgstr "Brugere"
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:22
-#: lib/helheim_web/templates/admin/user/_users.html.eex:29
+#: lib/helheim_web/templates/admin/user/_users.html.eex:30
 #, elixir-autogen
 msgid "Verified at"
 msgstr "Verifikationsdato"
 
-#: lib/helheim_web/templates/admin/user/_users.html.eex:26
+#: lib/helheim_web/templates/admin/user/_users.html.eex:27
 #, elixir-autogen
 msgid "IP"
 msgstr "IP"
 
-#: lib/helheim_web/templates/admin/user/_users.html.eex:23
+#: lib/helheim_web/templates/admin/user/_users.html.eex:24
 #, elixir-autogen
 msgid "Last Login at"
 msgstr "Seneste logindato"
@@ -2207,7 +2207,7 @@ msgid "This can either mean that an admin has not yet had the time to decide on 
 msgstr "Dette kan betyde at en admin endnu ikke har haft tid til at vurdere om du kan verificeres, eller det kan være at det blev vurderet at du ikke levede op til kriterierne for verifikation."
 
 #: lib/helheim_web/templates/help/verification.html.eex:3
-#: lib/helheim_web/templates/layout/sidebar.html.eex:48
+#: lib/helheim_web/templates/layout/sidebar.html.eex:54
 #, elixir-autogen
 msgid "User verification"
 msgstr "Brugerverifikation"
@@ -2237,35 +2237,35 @@ msgstr "Du er verificeret!"
 msgid "In short, a verified user is a user that an admin has deemed as not being a fake or empty profile."
 msgstr "Kort fortalt bliver man en verificeret bruger når en admin har vurderet at man ikke har en tom eller uærlig profil og samtidig lever op til sitets regler."
 
-#: lib/helheim_web/templates/admin/user/_blocks.html.eex:9
+#: lib/helheim_web/templates/admin/user/_blocks.html.eex:10
 #, elixir-autogen
 msgid "Blockee"
 msgstr "Hvem er blokeret"
 
-#: lib/helheim_web/templates/admin/user/_blocks.html.eex:7
+#: lib/helheim_web/templates/admin/user/_blocks.html.eex:8
 #, elixir-autogen
 msgid "Blocker"
 msgstr "Hvem har blokeret"
 
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:9
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:10
 #, elixir-autogen
 msgid "Published At"
 msgstr "Udgivelsesdato"
 
-#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:9
 #, elixir-autogen
 msgid "Topic"
 msgstr "Tråd"
 
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:10
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:11
 #, elixir-autogen
 msgid "Views/Comments"
 msgstr "Visninger/Kommentarer"
 
-#: lib/helheim_web/templates/admin/user/_blocks.html.eex:10
-#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:9
-#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:9
-#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:9
+#: lib/helheim_web/templates/admin/user/_blocks.html.eex:11
+#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:10
+#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:10
+#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:10
 #: lib/helheim_web/templates/mod/calendar_event/index.html.eex:11
 #, elixir-autogen
 msgid "When"
@@ -2282,14 +2282,14 @@ msgstr "Dette emne er låst"
 
 #: lib/helheim_web/templates/calendar_event/index.html.eex:5
 #: lib/helheim_web/templates/calendar_event/new.html.eex:1
-#: lib/helheim_web/templates/page/front_page.html.eex:70
+#: lib/helheim_web/templates/page/front_page.html.eex:58
 #, elixir-autogen
 msgid "Create event"
 msgstr "Opret begivenhed"
 
 #: lib/helheim_web/templates/calendar_event/index.html.eex:1
 #: lib/helheim_web/templates/calendar_event/show.html.eex:2
-#: lib/helheim_web/templates/layout/sidebar.html.eex:29
+#: lib/helheim_web/templates/layout/sidebar.html.eex:35
 #: lib/helheim_web/templates/layout/sidebar_mod.html.eex:6
 #: lib/helheim_web/templates/mod/calendar_event/index.html.eex:3
 #: lib/helheim_web/templates/mod/calendar_event/show.html.eex:3
@@ -2426,7 +2426,7 @@ msgid_plural "There are currently %{count} online users"
 msgstr[0] "Der er i øjeblikket %{count} online bruger"
 msgstr[1] "Der er i øjeblikket %{count} online brugere"
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:22
+#: lib/helheim_web/templates/layout/sidebar.html.eex:28
 #, elixir-autogen
 msgid "Online users"
 msgstr "Online brugere"
@@ -2472,17 +2472,17 @@ msgstr "Gem præferencer"
 msgid "%{count} people"
 msgstr "%{count} personer"
 
-#: lib/helheim_web/templates/page/front_page.html.eex:64
+#: lib/helheim_web/templates/page/front_page.html.eex:52
 #, elixir-autogen
 msgid "It looks like there are no upcoming events..."
 msgstr "Det ser ud til at der ikke er nogle kommende begivenheder…"
 
-#: lib/helheim_web/templates/page/front_page.html.eex:65
+#: lib/helheim_web/templates/page/front_page.html.eex:53
 #, elixir-autogen
 msgid "Tell us about an event so we can add it:"
 msgstr "Fortæl os om en begivenhed så vi kan tilføje den:"
 
-#: lib/helheim_web/templates/page/front_page.html.eex:55
+#: lib/helheim_web/templates/page/front_page.html.eex:43
 #, elixir-autogen
 msgid "Events"
 msgstr "Begivenheder"
@@ -2524,7 +2524,7 @@ msgstr "Moderator"
 msgid "Moderators"
 msgstr "Moderatorer"
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:54
+#: lib/helheim_web/templates/layout/sidebar.html.eex:60
 #: lib/helheim_web/templates/page/staff.html.eex:3
 #, elixir-format, elixir-autogen
 msgid "Staff"
@@ -2727,6 +2727,7 @@ msgstr "Slet lyttehistorik"
 msgid "Latest listens"
 msgstr "Seneste afspilninger"
 
+#: lib/helheim_web/templates/music/index.html.eex:28
 #: lib/helheim_web/templates/song/show.html.eex:36
 #, elixir-autogen, elixir-format
 msgid "Listens"
@@ -2737,6 +2738,7 @@ msgstr "Afspilninger"
 msgid "Music from %{username}"
 msgstr "Musik fra %{username}"
 
+#: lib/helheim_web/templates/music/index.html.eex:94
 #: lib/helheim_web/templates/song/recent.html.eex:6
 #: lib/helheim_web/templates/song_listen/index.html.eex:9
 #: lib/helheim_web/templates/song_listen/index.html.eex:21
@@ -2755,7 +2757,8 @@ msgstr "Ingen har lyttet til denne sang endnu..."
 msgid "Recent listeners"
 msgstr "Seneste lyttere"
 
-#: lib/helheim_web/templates/page/front_page.html.eex:84
+#: lib/helheim_web/templates/music/index.html.eex:10
+#: lib/helheim_web/templates/page/front_page.html.eex:71
 #: lib/helheim_web/templates/song/recent.html.eex:1
 #, elixir-autogen, elixir-format
 msgid "Recent listens"
@@ -2766,6 +2769,7 @@ msgstr "Seneste afspilninger"
 msgid "Song"
 msgstr "Sang"
 
+#: lib/helheim_web/templates/music/index.html.eex:92
 #: lib/helheim_web/templates/song_listen/index.html.eex:19
 #, elixir-autogen, elixir-format
 msgid "Top artists"
@@ -2796,7 +2800,7 @@ msgstr "Er du sikker? Dine afspilninger af denne sang bliver fjernet permanent!"
 msgid "Remove my name from this song"
 msgstr "Fjern mit navn fra denne sang"
 
-#: lib/helheim_web/controllers/song_controller.ex:162
+#: lib/helheim_web/controllers/song_controller.ex:177
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr "Dine afspilninger er blevet fjernet fra denne sang."
@@ -2806,6 +2810,7 @@ msgstr "Dine afspilninger er blevet fjernet fra denne sang."
 msgid "Album on Last.fm"
 msgstr "Album på Last.fm"
 
+#: lib/helheim_web/templates/music/artist.html.eex:24
 #: lib/helheim_web/templates/song/show.html.eex:53
 #, elixir-autogen, elixir-format
 msgid "Artist on Last.fm"
@@ -2883,21 +2888,21 @@ msgstr "Din Last.fm-konto er blevet afbrudt."
 msgid "Your Last.fm account is now connected!"
 msgstr "Din Last.fm-konto er nu forbundet!"
 
-#: lib/helheim_web/controllers/song_controller.ex:56
-#: lib/helheim_web/templates/page/front_page.html.eex:98
-#: lib/helheim_web/templates/page/front_page.html.eex:106
+#: lib/helheim_web/controllers/song_controller.ex:59
+#: lib/helheim_web/templates/music/index.html.eex:135
+#: lib/helheim_web/templates/music/index.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "No songs have been listened to in this period yet..."
 msgstr "Der er ikke lyttet til nogen sange i denne periode endnu..."
 
-#: lib/helheim_web/controllers/song_controller.ex:28
-#: lib/helheim_web/templates/page/front_page.html.eex:94
+#: lib/helheim_web/controllers/song_controller.ex:31
+#: lib/helheim_web/templates/music/index.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 24 hours"
 msgstr "Top sange, seneste 24 timer"
 
-#: lib/helheim_web/controllers/song_controller.ex:32
-#: lib/helheim_web/templates/page/front_page.html.eex:102
+#: lib/helheim_web/controllers/song_controller.ex:35
+#: lib/helheim_web/templates/music/index.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 7 days"
 msgstr "Top sange, seneste 7 dage"
@@ -2913,42 +2918,143 @@ msgid "Year"
 msgstr "Årstal"
 
 #: lib/helheim_web/templates/song/show.html.eex:11
-#: lib/helheim_web/views/song_view.ex:44
-#: lib/helheim_web/views/song_view.ex:45
+#: lib/helheim_web/views/song_view.ex:53
+#: lib/helheim_web/views/song_view.ex:54
 #, elixir-autogen, elixir-format
 msgid "Play preview"
 msgstr "Hør smagsprøve"
 
-#: lib/helheim_web/controllers/song_controller.ex:36
-#: lib/helheim_web/templates/page/front_page.html.eex:114
+#: lib/helheim_web/controllers/song_controller.ex:39
+#: lib/helheim_web/templates/music/index.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Most upvoted songs, past 24 hours"
 msgstr "Mest likede sange, seneste 24 timer"
 
-#: lib/helheim_web/controllers/song_controller.ex:40
-#: lib/helheim_web/templates/page/front_page.html.eex:122
+#: lib/helheim_web/controllers/song_controller.ex:43
+#: lib/helheim_web/templates/music/index.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Most upvoted songs, past 7 days"
 msgstr "Mest likede sange, seneste 7 dage"
 
-#: lib/helheim_web/controllers/song_controller.ex:57
-#: lib/helheim_web/templates/page/front_page.html.eex:118
-#: lib/helheim_web/templates/page/front_page.html.eex:126
+#: lib/helheim_web/controllers/song_controller.ex:60
+#: lib/helheim_web/templates/music/index.html.eex:153
+#: lib/helheim_web/templates/music/index.html.eex:161
 #, elixir-autogen, elixir-format
 msgid "No songs have been upvoted in this period yet..."
 msgstr "Ingen sange har fået likes i denne periode endnu..."
 
-#: lib/helheim_web/views/song_view.ex:91
+#: lib/helheim_web/views/song_view.ex:111
 #, elixir-autogen, elixir-format
 msgid "Upvote"
 msgstr "Like"
 
+#: lib/helheim_web/templates/music/index.html.eex:32
 #: lib/helheim_web/templates/song/show.html.eex:40
 #, elixir-autogen, elixir-format
 msgid "Upvotes"
 msgstr "Likes"
 
-#: lib/helheim_web/views/song_view.ex:92
+#: lib/helheim_web/views/song_view.ex:112
 #, elixir-autogen, elixir-format
 msgid "Remove your upvote"
 msgstr "Fjern like"
+
+#: lib/helheim_web/views/music_view.ex:14
+#, elixir-autogen, elixir-format
+msgid "%{decade}s"
+msgstr "%{decade}'erne"
+
+#: lib/helheim_web/views/music_view.ex:21
+#, elixir-autogen, elixir-format
+msgid "%{short}s"
+msgstr "%{short}'erne"
+
+#: lib/helheim_web/templates/music/artist.html.eex:3
+#: lib/helheim_web/templates/music/decade.html.eex:3
+#: lib/helheim_web/templates/music/genre.html.eex:3
+#, elixir-autogen, elixir-format
+msgid "All music"
+msgstr "Al musik"
+
+#: lib/helheim_web/templates/music/index.html.eex:24
+#, elixir-autogen, elixir-format
+msgid "Artists"
+msgstr "Kunstnere"
+
+#: lib/helheim_web/templates/music/index.html.eex:69
+#, elixir-autogen, elixir-format
+msgid "Decades"
+msgstr "Årtier"
+
+#: lib/helheim_web/templates/music/index.html.eex:4
+#, elixir-autogen, elixir-format
+msgid "Everything the site is listening to: the current charts, the genres and decades we keep coming back to, and the artists we play the most."
+msgstr "Alt hvad siden lytter til: de aktuelle hitlister, de genrer og årtier vi vender tilbage til, og de kunstnere vi spiller mest."
+
+#: lib/helheim_web/templates/music/index.html.eex:46
+#, elixir-autogen, elixir-format
+msgid "Genres"
+msgstr "Genrer"
+
+#: lib/helheim_web/templates/music/index.html.eex:16
+#, elixir-autogen, elixir-format
+msgid "Helheim in numbers"
+msgstr "Helheim i tal"
+
+#: lib/helheim_web/templates/music/index.html.eex:36
+#, elixir-autogen, elixir-format
+msgid "Listeners"
+msgstr "Lyttere"
+
+#: lib/helheim_web/templates/layout/sidebar.html.eex:10
+#: lib/helheim_web/templates/music/index.html.eex:1
+#, elixir-autogen, elixir-format
+msgid "Music"
+msgstr "Musik"
+
+#: lib/helheim_web/templates/song/show.html.eex:90
+#, elixir-autogen, elixir-format
+msgid "No one has upvoted this song yet..."
+msgstr "Ingen har liket denne sang endnu..."
+
+#: lib/helheim_web/templates/music/index.html.eex:48
+#, elixir-autogen, elixir-format
+msgid "No songs have been tagged with a genre yet..."
+msgstr "Ingen sange er blevet tagget med en genre endnu..."
+
+#: lib/helheim_web/templates/music/artist.html.eex:35
+#: lib/helheim_web/templates/music/decade.html.eex:11
+#: lib/helheim_web/templates/music/genre.html.eex:11
+#, elixir-autogen, elixir-format
+msgid "No songs here yet..."
+msgstr "Ingen sange her endnu..."
+
+#: lib/helheim_web/templates/music/index.html.eex:71
+#, elixir-autogen, elixir-format
+msgid "No songs with a known release year yet..."
+msgstr "Ingen sange med et kendt udgivelsesår endnu..."
+
+#: lib/helheim_web/templates/music/index.html.eex:20
+#, elixir-autogen, elixir-format
+msgid "Songs"
+msgstr "Sange"
+
+#: lib/helheim_web/templates/music/artist.html.eex:30
+#, elixir-autogen, elixir-format
+msgid "The most listened to songs by %{artist}."
+msgstr "De mest afspillede sange af %{artist}."
+
+#: lib/helheim_web/templates/music/decade.html.eex:6
+#, elixir-autogen, elixir-format
+msgid "The most listened to songs released in the %{decade}."
+msgstr "De mest afspillede sange udgivet i %{decade}."
+
+#: lib/helheim_web/templates/music/genre.html.eex:6
+#, elixir-autogen, elixir-format
+msgid "The most listened to songs tagged %{genre}."
+msgstr "De mest afspillede sange tagget %{genre}."
+
+#: lib/helheim_web/templates/song/show.html.eex:88
+#, elixir-autogen, elixir-format
+msgid "Upvoted by"
+msgstr "Liket af"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -50,7 +50,7 @@ msgstr ""
 
 #: lib/helheim_web/templates/account/edit.html.eex:24
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:13
-#: lib/helheim_web/templates/admin/user/_users.html.eex:14
+#: lib/helheim_web/templates/admin/user/_users.html.eex:15
 #: lib/helheim_web/templates/admin/user/index.html.eex:26
 #: lib/helheim_web/templates/confirmation/new.html.eex:10
 #: lib/helheim_web/templates/password_reset/new.html.eex:10
@@ -72,7 +72,7 @@ msgstr ""
 
 #: lib/helheim_web/templates/account/edit.html.eex:14
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:10
-#: lib/helheim_web/templates/admin/user/_users.html.eex:11
+#: lib/helheim_web/templates/admin/user/_users.html.eex:12
 #: lib/helheim_web/templates/admin/user/index.html.eex:21
 #: lib/helheim_web/templates/registration/new.html.eex:23
 #, elixir-autogen
@@ -112,7 +112,7 @@ msgid "Sign In"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:7
-#: lib/helheim_web/templates/admin/user/_users.html.eex:8
+#: lib/helheim_web/templates/admin/user/_users.html.eex:9
 #: lib/helheim_web/templates/admin/user/index.html.eex:16
 #: lib/helheim_web/templates/profile/index.html.eex:15
 #: lib/helheim_web/templates/registration/new.html.eex:9
@@ -462,25 +462,25 @@ msgstr ""
 msgid "Remember me"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:28
+#: lib/helheim_web/templates/page/front_page.html.eex:16
 #: lib/helheim_web/templates/profile/show.html.eex:76
 #, elixir-autogen
 msgid "Newest Blogs"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:40
+#: lib/helheim_web/templates/page/front_page.html.eex:28
 #: lib/helheim_web/templates/profile/show.html.eex:87
 #, elixir-autogen
 msgid "Newest Forum Posts"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:135
+#: lib/helheim_web/templates/page/front_page.html.eex:91
 #: lib/helheim_web/templates/profile/show.html.eex:111
 #, elixir-autogen
 msgid "Newest Photos"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:63
+#: lib/helheim_web/templates/layout/sidebar.html.eex:69
 #, elixir-autogen
 msgid "Your Profile"
 msgstr ""
@@ -504,14 +504,14 @@ msgstr ""
 
 #: lib/helheim_web/templates/blog_post/edit.html.eex:2
 #: lib/helheim_web/templates/blog_post/new.html.eex:2
-#: lib/helheim_web/templates/layout/sidebar.html.eex:84
+#: lib/helheim_web/templates/layout/sidebar.html.eex:90
 #, elixir-autogen
 msgid "Your Blog Posts"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/forum_category/index.html.eex:13
 #: lib/helheim_web/templates/admin/forum_category/index.html.eex:39
-#: lib/helheim_web/templates/admin/term/index.html.eex:35
+#: lib/helheim_web/templates/admin/term/index.html.eex:36
 #: lib/helheim_web/templates/blog_post/show.html.eex:30
 #: lib/helheim_web/templates/friendship/_my_active_friendships.html.eex:23
 #: lib/helheim_web/templates/friendship/_my_pending_friendships.html.eex:28
@@ -564,8 +564,8 @@ msgstr ""
 
 #: lib/helheim_web/templates/admin/forum/form.html.eex:4
 #: lib/helheim_web/templates/admin/forum_category/form.html.eex:4
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:8
-#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:9
+#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:9
 #: lib/helheim_web/templates/blog_post/form.html.eex:4
 #: lib/helheim_web/templates/calendar_event/_form.html.eex:4
 #: lib/helheim_web/templates/forum_topic/form.html.eex:4
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Comment created successfully"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:68
+#: lib/helheim_web/templates/layout/sidebar.html.eex:74
 #: lib/helheim_web/views/comment_view.ex:16
 #, elixir-autogen
 msgid "Guest Book"
@@ -599,11 +599,11 @@ msgstr ""
 
 #: lib/helheim_web/templates/comment/comments.html.eex:9
 #: lib/helheim_web/templates/page/front_page.html.eex:5
+#: lib/helheim_web/templates/page/front_page.html.eex:17
 #: lib/helheim_web/templates/page/front_page.html.eex:29
-#: lib/helheim_web/templates/page/front_page.html.eex:41
-#: lib/helheim_web/templates/page/front_page.html.eex:56
-#: lib/helheim_web/templates/page/front_page.html.eex:85
-#: lib/helheim_web/templates/page/front_page.html.eex:136
+#: lib/helheim_web/templates/page/front_page.html.eex:44
+#: lib/helheim_web/templates/page/front_page.html.eex:72
+#: lib/helheim_web/templates/page/front_page.html.eex:92
 #: lib/helheim_web/templates/profile/show.html.eex:81
 #: lib/helheim_web/templates/profile/show.html.eex:104
 #: lib/helheim_web/templates/profile/show.html.eex:117
@@ -665,7 +665,7 @@ msgid_plural "You have %{count} notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:80
+#: lib/helheim_web/templates/layout/sidebar.html.eex:86
 #: lib/helheim_web/templates/private_conversation/index.html.eex:1
 #, elixir-autogen
 msgid "Private Messages"
@@ -830,7 +830,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:89
+#: lib/helheim_web/templates/layout/sidebar.html.eex:95
 #, elixir-autogen
 msgid "Your Photo Albums"
 msgstr ""
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Administration"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:9
 #: lib/helheim_web/templates/blog_post/form.html.eex:12
 #: lib/helheim_web/templates/forum_reply/form.html.eex:12
 #: lib/helheim_web/templates/forum_topic/form.html.eex:12
@@ -942,7 +942,7 @@ msgstr ""
 #: lib/helheim_web/templates/forum_topic/edit.html.eex:2
 #: lib/helheim_web/templates/forum_topic/new.html.eex:2
 #: lib/helheim_web/templates/forum_topic/show.html.eex:2
-#: lib/helheim_web/templates/layout/sidebar.html.eex:10
+#: lib/helheim_web/templates/layout/sidebar.html.eex:16
 #, elixir-autogen
 msgid "Forums"
 msgstr ""
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "Submit new reply"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:60
+#: lib/helheim_web/templates/layout/sidebar.html.eex:66
 #, elixir-autogen
 msgid "You"
 msgstr ""
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "However, that doesn't meant that you should be an dick, so behave!"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/term/index.html.eex:15
+#: lib/helheim_web/templates/admin/term/index.html.eex:16
 #: lib/helheim_web/templates/mod/calendar_event/index.html.eex:13
 #, elixir-autogen
 msgid "Inserted at"
@@ -1140,7 +1140,7 @@ msgid "New Terms"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/term/form.html.eex:14
-#: lib/helheim_web/templates/admin/term/index.html.eex:17
+#: lib/helheim_web/templates/admin/term/index.html.eex:18
 #, elixir-autogen
 msgid "Published?"
 msgstr ""
@@ -1190,7 +1190,7 @@ msgstr ""
 msgid "There doesn't seem to be any terms or rules written yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/admin/term/index.html.eex:16
+#: lib/helheim_web/templates/admin/term/index.html.eex:17
 #, elixir-autogen
 msgid "Updated at"
 msgstr ""
@@ -1253,7 +1253,7 @@ msgid "Comments"
 msgstr ""
 
 #: lib/helheim_web/templates/help/verification.html.eex:2
-#: lib/helheim_web/templates/layout/sidebar.html.eex:36
+#: lib/helheim_web/templates/layout/sidebar.html.eex:42
 #: lib/helheim_web/templates/page/staff.html.eex:2
 #, elixir-autogen
 msgid "Help"
@@ -1346,7 +1346,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:16
+#: lib/helheim_web/templates/layout/sidebar.html.eex:22
 #: lib/helheim_web/templates/profile/index.html.eex:2
 #, elixir-autogen
 msgid "Profiles"
@@ -1872,7 +1872,7 @@ msgid "Add to Contacts"
 msgstr ""
 
 #: lib/helheim_web/templates/friendship/index.html.eex:3
-#: lib/helheim_web/templates/layout/sidebar.html.eex:74
+#: lib/helheim_web/templates/layout/sidebar.html.eex:80
 #, elixir-autogen
 msgid "Contact List"
 msgstr ""
@@ -1959,7 +1959,7 @@ msgstr ""
 msgid "Hide comments?"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:42
+#: lib/helheim_web/templates/layout/sidebar.html.eex:48
 #, elixir-autogen
 msgid "Terms and Rules"
 msgstr ""
@@ -1995,7 +1995,7 @@ msgid "Blog Post"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:19
-#: lib/helheim_web/templates/admin/user/_users.html.eex:20
+#: lib/helheim_web/templates/admin/user/_users.html.eex:21
 #, elixir-autogen
 msgid "Confirmed at"
 msgstr ""
@@ -2006,17 +2006,17 @@ msgid "Confirmed?"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:16
-#: lib/helheim_web/templates/admin/user/_users.html.eex:17
+#: lib/helheim_web/templates/admin/user/_users.html.eex:18
 #, elixir-autogen
 msgid "Created at"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:4
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:7
-#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:7
-#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:7
-#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:7
-#: lib/helheim_web/templates/admin/user/_users.html.eex:5
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:8
+#: lib/helheim_web/templates/admin/user/_users.html.eex:6
 #, elixir-autogen
 msgid "ID"
 msgstr ""
@@ -2031,12 +2031,12 @@ msgstr ""
 msgid "Login Details"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_blocks.html.eex:32
+#: lib/helheim_web/templates/admin/user/_blocks.html.eex:34
 #: lib/helheim_web/templates/admin/user/_potential_alt_accounts.html.eex:7
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:38
-#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:29
-#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:32
-#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:32
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:40
+#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:31
+#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:34
+#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:34
 #: lib/helheim_web/templates/admin/user/_recent_photos.html.eex:22
 #, elixir-autogen
 msgid "None found"
@@ -2095,17 +2095,17 @@ msgid "Users"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:22
-#: lib/helheim_web/templates/admin/user/_users.html.eex:29
+#: lib/helheim_web/templates/admin/user/_users.html.eex:30
 #, elixir-autogen
 msgid "Verified at"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_users.html.eex:26
+#: lib/helheim_web/templates/admin/user/_users.html.eex:27
 #, elixir-autogen
 msgid "IP"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_users.html.eex:23
+#: lib/helheim_web/templates/admin/user/_users.html.eex:24
 #, elixir-autogen
 msgid "Last Login at"
 msgstr ""
@@ -2196,7 +2196,7 @@ msgid "This can either mean that an admin has not yet had the time to decide on 
 msgstr ""
 
 #: lib/helheim_web/templates/help/verification.html.eex:3
-#: lib/helheim_web/templates/layout/sidebar.html.eex:48
+#: lib/helheim_web/templates/layout/sidebar.html.eex:54
 #, elixir-autogen
 msgid "User verification"
 msgstr ""
@@ -2226,35 +2226,35 @@ msgstr ""
 msgid "In short, a verified user is a user that an admin has deemed as not being a fake or empty profile."
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_blocks.html.eex:9
+#: lib/helheim_web/templates/admin/user/_blocks.html.eex:10
 #, elixir-autogen
 msgid "Blockee"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_blocks.html.eex:7
+#: lib/helheim_web/templates/admin/user/_blocks.html.eex:8
 #, elixir-autogen
 msgid "Blocker"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:9
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:10
 #, elixir-autogen
 msgid "Published At"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:9
 #, elixir-autogen
 msgid "Topic"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:10
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:11
 #, elixir-autogen
 msgid "Views/Comments"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_blocks.html.eex:10
-#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:9
-#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:9
-#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:9
+#: lib/helheim_web/templates/admin/user/_blocks.html.eex:11
+#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:10
+#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:10
+#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:10
 #: lib/helheim_web/templates/mod/calendar_event/index.html.eex:11
 #, elixir-autogen
 msgid "When"
@@ -2271,14 +2271,14 @@ msgstr ""
 
 #: lib/helheim_web/templates/calendar_event/index.html.eex:5
 #: lib/helheim_web/templates/calendar_event/new.html.eex:1
-#: lib/helheim_web/templates/page/front_page.html.eex:70
+#: lib/helheim_web/templates/page/front_page.html.eex:58
 #, elixir-autogen
 msgid "Create event"
 msgstr ""
 
 #: lib/helheim_web/templates/calendar_event/index.html.eex:1
 #: lib/helheim_web/templates/calendar_event/show.html.eex:2
-#: lib/helheim_web/templates/layout/sidebar.html.eex:29
+#: lib/helheim_web/templates/layout/sidebar.html.eex:35
 #: lib/helheim_web/templates/layout/sidebar_mod.html.eex:6
 #: lib/helheim_web/templates/mod/calendar_event/index.html.eex:3
 #: lib/helheim_web/templates/mod/calendar_event/show.html.eex:3
@@ -2415,7 +2415,7 @@ msgid_plural "There are currently %{count} online users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:22
+#: lib/helheim_web/templates/layout/sidebar.html.eex:28
 #, elixir-autogen
 msgid "Online users"
 msgstr ""
@@ -2461,17 +2461,17 @@ msgstr ""
 msgid "%{count} people"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:64
+#: lib/helheim_web/templates/page/front_page.html.eex:52
 #, elixir-autogen
 msgid "It looks like there are no upcoming events..."
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:65
+#: lib/helheim_web/templates/page/front_page.html.eex:53
 #, elixir-autogen
 msgid "Tell us about an event so we can add it:"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:55
+#: lib/helheim_web/templates/page/front_page.html.eex:43
 #, elixir-autogen
 msgid "Events"
 msgstr ""
@@ -2513,7 +2513,7 @@ msgstr ""
 msgid "Moderators"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:54
+#: lib/helheim_web/templates/layout/sidebar.html.eex:60
 #: lib/helheim_web/templates/page/staff.html.eex:3
 #, elixir-format, elixir-autogen
 msgid "Staff"
@@ -2716,6 +2716,7 @@ msgstr ""
 msgid "Latest listens"
 msgstr ""
 
+#: lib/helheim_web/templates/music/index.html.eex:28
 #: lib/helheim_web/templates/song/show.html.eex:36
 #, elixir-autogen, elixir-format
 msgid "Listens"
@@ -2726,6 +2727,7 @@ msgstr ""
 msgid "Music from %{username}"
 msgstr ""
 
+#: lib/helheim_web/templates/music/index.html.eex:94
 #: lib/helheim_web/templates/song/recent.html.eex:6
 #: lib/helheim_web/templates/song_listen/index.html.eex:9
 #: lib/helheim_web/templates/song_listen/index.html.eex:21
@@ -2744,7 +2746,8 @@ msgstr ""
 msgid "Recent listeners"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:84
+#: lib/helheim_web/templates/music/index.html.eex:10
+#: lib/helheim_web/templates/page/front_page.html.eex:71
 #: lib/helheim_web/templates/song/recent.html.eex:1
 #, elixir-autogen, elixir-format
 msgid "Recent listens"
@@ -2755,6 +2758,7 @@ msgstr ""
 msgid "Song"
 msgstr ""
 
+#: lib/helheim_web/templates/music/index.html.eex:92
 #: lib/helheim_web/templates/song_listen/index.html.eex:19
 #, elixir-autogen, elixir-format
 msgid "Top artists"
@@ -2785,7 +2789,7 @@ msgstr ""
 msgid "Remove my name from this song"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:162
+#: lib/helheim_web/controllers/song_controller.ex:177
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr ""
@@ -2795,6 +2799,7 @@ msgstr ""
 msgid "Album on Last.fm"
 msgstr ""
 
+#: lib/helheim_web/templates/music/artist.html.eex:24
 #: lib/helheim_web/templates/song/show.html.eex:53
 #, elixir-autogen, elixir-format
 msgid "Artist on Last.fm"
@@ -2872,21 +2877,21 @@ msgstr ""
 msgid "Your Last.fm account is now connected!"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:56
-#: lib/helheim_web/templates/page/front_page.html.eex:98
-#: lib/helheim_web/templates/page/front_page.html.eex:106
+#: lib/helheim_web/controllers/song_controller.ex:59
+#: lib/helheim_web/templates/music/index.html.eex:135
+#: lib/helheim_web/templates/music/index.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "No songs have been listened to in this period yet..."
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:28
-#: lib/helheim_web/templates/page/front_page.html.eex:94
+#: lib/helheim_web/controllers/song_controller.ex:31
+#: lib/helheim_web/templates/music/index.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 24 hours"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:32
-#: lib/helheim_web/templates/page/front_page.html.eex:102
+#: lib/helheim_web/controllers/song_controller.ex:35
+#: lib/helheim_web/templates/music/index.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 7 days"
 msgstr ""
@@ -2902,42 +2907,143 @@ msgid "Year"
 msgstr ""
 
 #: lib/helheim_web/templates/song/show.html.eex:11
-#: lib/helheim_web/views/song_view.ex:44
-#: lib/helheim_web/views/song_view.ex:45
+#: lib/helheim_web/views/song_view.ex:53
+#: lib/helheim_web/views/song_view.ex:54
 #, elixir-autogen, elixir-format
 msgid "Play preview"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:36
-#: lib/helheim_web/templates/page/front_page.html.eex:114
+#: lib/helheim_web/controllers/song_controller.ex:39
+#: lib/helheim_web/templates/music/index.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Most upvoted songs, past 24 hours"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:40
-#: lib/helheim_web/templates/page/front_page.html.eex:122
+#: lib/helheim_web/controllers/song_controller.ex:43
+#: lib/helheim_web/templates/music/index.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Most upvoted songs, past 7 days"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:57
-#: lib/helheim_web/templates/page/front_page.html.eex:118
-#: lib/helheim_web/templates/page/front_page.html.eex:126
+#: lib/helheim_web/controllers/song_controller.ex:60
+#: lib/helheim_web/templates/music/index.html.eex:153
+#: lib/helheim_web/templates/music/index.html.eex:161
 #, elixir-autogen, elixir-format
 msgid "No songs have been upvoted in this period yet..."
 msgstr ""
 
-#: lib/helheim_web/views/song_view.ex:91
+#: lib/helheim_web/views/song_view.ex:111
 #, elixir-autogen, elixir-format
 msgid "Upvote"
 msgstr ""
 
+#: lib/helheim_web/templates/music/index.html.eex:32
 #: lib/helheim_web/templates/song/show.html.eex:40
 #, elixir-autogen, elixir-format
 msgid "Upvotes"
 msgstr ""
 
-#: lib/helheim_web/views/song_view.ex:92
+#: lib/helheim_web/views/song_view.ex:112
 #, elixir-autogen, elixir-format
 msgid "Remove your upvote"
+msgstr ""
+
+#: lib/helheim_web/views/music_view.ex:14
+#, elixir-autogen, elixir-format
+msgid "%{decade}s"
+msgstr ""
+
+#: lib/helheim_web/views/music_view.ex:21
+#, elixir-autogen, elixir-format
+msgid "%{short}s"
+msgstr ""
+
+#: lib/helheim_web/templates/music/artist.html.eex:3
+#: lib/helheim_web/templates/music/decade.html.eex:3
+#: lib/helheim_web/templates/music/genre.html.eex:3
+#, elixir-autogen, elixir-format
+msgid "All music"
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:24
+#, elixir-autogen, elixir-format
+msgid "Artists"
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:69
+#, elixir-autogen, elixir-format
+msgid "Decades"
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:4
+#, elixir-autogen, elixir-format
+msgid "Everything the site is listening to: the current charts, the genres and decades we keep coming back to, and the artists we play the most."
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:46
+#, elixir-autogen, elixir-format
+msgid "Genres"
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:16
+#, elixir-autogen, elixir-format
+msgid "Helheim in numbers"
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:36
+#, elixir-autogen, elixir-format
+msgid "Listeners"
+msgstr ""
+
+#: lib/helheim_web/templates/layout/sidebar.html.eex:10
+#: lib/helheim_web/templates/music/index.html.eex:1
+#, elixir-autogen, elixir-format
+msgid "Music"
+msgstr ""
+
+#: lib/helheim_web/templates/song/show.html.eex:90
+#, elixir-autogen, elixir-format
+msgid "No one has upvoted this song yet..."
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:48
+#, elixir-autogen, elixir-format
+msgid "No songs have been tagged with a genre yet..."
+msgstr ""
+
+#: lib/helheim_web/templates/music/artist.html.eex:35
+#: lib/helheim_web/templates/music/decade.html.eex:11
+#: lib/helheim_web/templates/music/genre.html.eex:11
+#, elixir-autogen, elixir-format
+msgid "No songs here yet..."
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:71
+#, elixir-autogen, elixir-format
+msgid "No songs with a known release year yet..."
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:20
+#, elixir-autogen, elixir-format
+msgid "Songs"
+msgstr ""
+
+#: lib/helheim_web/templates/music/artist.html.eex:30
+#, elixir-autogen, elixir-format
+msgid "The most listened to songs by %{artist}."
+msgstr ""
+
+#: lib/helheim_web/templates/music/decade.html.eex:6
+#, elixir-autogen, elixir-format
+msgid "The most listened to songs released in the %{decade}."
+msgstr ""
+
+#: lib/helheim_web/templates/music/genre.html.eex:6
+#, elixir-autogen, elixir-format
+msgid "The most listened to songs tagged %{genre}."
+msgstr ""
+
+#: lib/helheim_web/templates/song/show.html.eex:88
+#, elixir-autogen, elixir-format
+msgid "Upvoted by"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -50,7 +50,7 @@ msgstr ""
 
 #: lib/helheim_web/templates/account/edit.html.eex:24
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:13
-#: lib/helheim_web/templates/admin/user/_users.html.eex:14
+#: lib/helheim_web/templates/admin/user/_users.html.eex:15
 #: lib/helheim_web/templates/admin/user/index.html.eex:26
 #: lib/helheim_web/templates/confirmation/new.html.eex:10
 #: lib/helheim_web/templates/password_reset/new.html.eex:10
@@ -72,7 +72,7 @@ msgstr ""
 
 #: lib/helheim_web/templates/account/edit.html.eex:14
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:10
-#: lib/helheim_web/templates/admin/user/_users.html.eex:11
+#: lib/helheim_web/templates/admin/user/_users.html.eex:12
 #: lib/helheim_web/templates/admin/user/index.html.eex:21
 #: lib/helheim_web/templates/registration/new.html.eex:23
 #, elixir-autogen
@@ -112,7 +112,7 @@ msgid "Sign In"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:7
-#: lib/helheim_web/templates/admin/user/_users.html.eex:8
+#: lib/helheim_web/templates/admin/user/_users.html.eex:9
 #: lib/helheim_web/templates/admin/user/index.html.eex:16
 #: lib/helheim_web/templates/profile/index.html.eex:15
 #: lib/helheim_web/templates/registration/new.html.eex:9
@@ -462,25 +462,25 @@ msgstr ""
 msgid "Remember me"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:28
+#: lib/helheim_web/templates/page/front_page.html.eex:16
 #: lib/helheim_web/templates/profile/show.html.eex:76
 #, elixir-autogen
 msgid "Newest Blogs"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:40
+#: lib/helheim_web/templates/page/front_page.html.eex:28
 #: lib/helheim_web/templates/profile/show.html.eex:87
 #, elixir-autogen
 msgid "Newest Forum Posts"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:135
+#: lib/helheim_web/templates/page/front_page.html.eex:91
 #: lib/helheim_web/templates/profile/show.html.eex:111
 #, elixir-autogen
 msgid "Newest Photos"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:63
+#: lib/helheim_web/templates/layout/sidebar.html.eex:69
 #, elixir-autogen
 msgid "Your Profile"
 msgstr ""
@@ -504,14 +504,14 @@ msgstr ""
 
 #: lib/helheim_web/templates/blog_post/edit.html.eex:2
 #: lib/helheim_web/templates/blog_post/new.html.eex:2
-#: lib/helheim_web/templates/layout/sidebar.html.eex:84
+#: lib/helheim_web/templates/layout/sidebar.html.eex:90
 #, elixir-autogen
 msgid "Your Blog Posts"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/forum_category/index.html.eex:13
 #: lib/helheim_web/templates/admin/forum_category/index.html.eex:39
-#: lib/helheim_web/templates/admin/term/index.html.eex:35
+#: lib/helheim_web/templates/admin/term/index.html.eex:36
 #: lib/helheim_web/templates/blog_post/show.html.eex:30
 #: lib/helheim_web/templates/friendship/_my_active_friendships.html.eex:23
 #: lib/helheim_web/templates/friendship/_my_pending_friendships.html.eex:28
@@ -564,8 +564,8 @@ msgstr ""
 
 #: lib/helheim_web/templates/admin/forum/form.html.eex:4
 #: lib/helheim_web/templates/admin/forum_category/form.html.eex:4
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:8
-#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:9
+#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:9
 #: lib/helheim_web/templates/blog_post/form.html.eex:4
 #: lib/helheim_web/templates/calendar_event/_form.html.eex:4
 #: lib/helheim_web/templates/forum_topic/form.html.eex:4
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Comment created successfully"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:68
+#: lib/helheim_web/templates/layout/sidebar.html.eex:74
 #: lib/helheim_web/views/comment_view.ex:16
 #, elixir-autogen
 msgid "Guest Book"
@@ -599,11 +599,11 @@ msgstr ""
 
 #: lib/helheim_web/templates/comment/comments.html.eex:9
 #: lib/helheim_web/templates/page/front_page.html.eex:5
+#: lib/helheim_web/templates/page/front_page.html.eex:17
 #: lib/helheim_web/templates/page/front_page.html.eex:29
-#: lib/helheim_web/templates/page/front_page.html.eex:41
-#: lib/helheim_web/templates/page/front_page.html.eex:56
-#: lib/helheim_web/templates/page/front_page.html.eex:85
-#: lib/helheim_web/templates/page/front_page.html.eex:136
+#: lib/helheim_web/templates/page/front_page.html.eex:44
+#: lib/helheim_web/templates/page/front_page.html.eex:72
+#: lib/helheim_web/templates/page/front_page.html.eex:92
 #: lib/helheim_web/templates/profile/show.html.eex:81
 #: lib/helheim_web/templates/profile/show.html.eex:104
 #: lib/helheim_web/templates/profile/show.html.eex:117
@@ -665,7 +665,7 @@ msgid_plural "You have %{count} notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:80
+#: lib/helheim_web/templates/layout/sidebar.html.eex:86
 #: lib/helheim_web/templates/private_conversation/index.html.eex:1
 #, elixir-autogen
 msgid "Private Messages"
@@ -830,7 +830,7 @@ msgstr ""
 msgid "Uploaded"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:89
+#: lib/helheim_web/templates/layout/sidebar.html.eex:95
 #, elixir-autogen
 msgid "Your Photo Albums"
 msgstr ""
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Administration"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:9
 #: lib/helheim_web/templates/blog_post/form.html.eex:12
 #: lib/helheim_web/templates/forum_reply/form.html.eex:12
 #: lib/helheim_web/templates/forum_topic/form.html.eex:12
@@ -942,7 +942,7 @@ msgstr ""
 #: lib/helheim_web/templates/forum_topic/edit.html.eex:2
 #: lib/helheim_web/templates/forum_topic/new.html.eex:2
 #: lib/helheim_web/templates/forum_topic/show.html.eex:2
-#: lib/helheim_web/templates/layout/sidebar.html.eex:10
+#: lib/helheim_web/templates/layout/sidebar.html.eex:16
 #, elixir-autogen
 msgid "Forums"
 msgstr ""
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "Submit new reply"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:60
+#: lib/helheim_web/templates/layout/sidebar.html.eex:66
 #, elixir-autogen
 msgid "You"
 msgstr ""
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "However, that doesn't meant that you should be an dick, so behave!"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/term/index.html.eex:15
+#: lib/helheim_web/templates/admin/term/index.html.eex:16
 #: lib/helheim_web/templates/mod/calendar_event/index.html.eex:13
 #, elixir-autogen
 msgid "Inserted at"
@@ -1140,7 +1140,7 @@ msgid "New Terms"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/term/form.html.eex:14
-#: lib/helheim_web/templates/admin/term/index.html.eex:17
+#: lib/helheim_web/templates/admin/term/index.html.eex:18
 #, elixir-autogen
 msgid "Published?"
 msgstr ""
@@ -1190,7 +1190,7 @@ msgstr ""
 msgid "There doesn't seem to be any terms or rules written yet..."
 msgstr ""
 
-#: lib/helheim_web/templates/admin/term/index.html.eex:16
+#: lib/helheim_web/templates/admin/term/index.html.eex:17
 #, elixir-autogen
 msgid "Updated at"
 msgstr ""
@@ -1253,7 +1253,7 @@ msgid "Comments"
 msgstr ""
 
 #: lib/helheim_web/templates/help/verification.html.eex:2
-#: lib/helheim_web/templates/layout/sidebar.html.eex:36
+#: lib/helheim_web/templates/layout/sidebar.html.eex:42
 #: lib/helheim_web/templates/page/staff.html.eex:2
 #, elixir-autogen
 msgid "Help"
@@ -1346,7 +1346,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:16
+#: lib/helheim_web/templates/layout/sidebar.html.eex:22
 #: lib/helheim_web/templates/profile/index.html.eex:2
 #, elixir-autogen
 msgid "Profiles"
@@ -1872,7 +1872,7 @@ msgid "Add to Contacts"
 msgstr ""
 
 #: lib/helheim_web/templates/friendship/index.html.eex:3
-#: lib/helheim_web/templates/layout/sidebar.html.eex:74
+#: lib/helheim_web/templates/layout/sidebar.html.eex:80
 #, elixir-autogen
 msgid "Contact List"
 msgstr ""
@@ -1959,7 +1959,7 @@ msgstr ""
 msgid "Hide comments?"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:42
+#: lib/helheim_web/templates/layout/sidebar.html.eex:48
 #, elixir-autogen
 msgid "Terms and Rules"
 msgstr ""
@@ -1995,7 +1995,7 @@ msgid "Blog Post"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:19
-#: lib/helheim_web/templates/admin/user/_users.html.eex:20
+#: lib/helheim_web/templates/admin/user/_users.html.eex:21
 #, elixir-autogen
 msgid "Confirmed at"
 msgstr ""
@@ -2006,17 +2006,17 @@ msgid "Confirmed?"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:16
-#: lib/helheim_web/templates/admin/user/_users.html.eex:17
+#: lib/helheim_web/templates/admin/user/_users.html.eex:18
 #, elixir-autogen
 msgid "Created at"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:4
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:7
-#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:7
-#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:7
-#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:7
-#: lib/helheim_web/templates/admin/user/_users.html.eex:5
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:8
+#: lib/helheim_web/templates/admin/user/_users.html.eex:6
 #, elixir-autogen
 msgid "ID"
 msgstr ""
@@ -2031,12 +2031,12 @@ msgstr ""
 msgid "Login Details"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_blocks.html.eex:32
+#: lib/helheim_web/templates/admin/user/_blocks.html.eex:34
 #: lib/helheim_web/templates/admin/user/_potential_alt_accounts.html.eex:7
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:38
-#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:29
-#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:32
-#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:32
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:40
+#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:31
+#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:34
+#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:34
 #: lib/helheim_web/templates/admin/user/_recent_photos.html.eex:22
 #, elixir-autogen
 msgid "None found"
@@ -2095,17 +2095,17 @@ msgid "Users"
 msgstr ""
 
 #: lib/helheim_web/templates/admin/user/_account_details.html.eex:22
-#: lib/helheim_web/templates/admin/user/_users.html.eex:29
+#: lib/helheim_web/templates/admin/user/_users.html.eex:30
 #, elixir-autogen
 msgid "Verified at"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_users.html.eex:26
+#: lib/helheim_web/templates/admin/user/_users.html.eex:27
 #, elixir-autogen
 msgid "IP"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_users.html.eex:23
+#: lib/helheim_web/templates/admin/user/_users.html.eex:24
 #, elixir-autogen
 msgid "Last Login at"
 msgstr ""
@@ -2196,7 +2196,7 @@ msgid "This can either mean that an admin has not yet had the time to decide on 
 msgstr ""
 
 #: lib/helheim_web/templates/help/verification.html.eex:3
-#: lib/helheim_web/templates/layout/sidebar.html.eex:48
+#: lib/helheim_web/templates/layout/sidebar.html.eex:54
 #, elixir-autogen
 msgid "User verification"
 msgstr ""
@@ -2226,35 +2226,35 @@ msgstr ""
 msgid "In short, a verified user is a user that an admin has deemed as not being a fake or empty profile."
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_blocks.html.eex:9
+#: lib/helheim_web/templates/admin/user/_blocks.html.eex:10
 #, elixir-autogen
 msgid "Blockee"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_blocks.html.eex:7
+#: lib/helheim_web/templates/admin/user/_blocks.html.eex:8
 #, elixir-autogen
 msgid "Blocker"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:9
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:10
 #, elixir-autogen
 msgid "Published At"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:8
+#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:9
 #, elixir-autogen
 msgid "Topic"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:10
+#: lib/helheim_web/templates/admin/user/_recent_blog_posts.html.eex:11
 #, elixir-autogen
 msgid "Views/Comments"
 msgstr ""
 
-#: lib/helheim_web/templates/admin/user/_blocks.html.eex:10
-#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:9
-#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:9
-#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:9
+#: lib/helheim_web/templates/admin/user/_blocks.html.eex:11
+#: lib/helheim_web/templates/admin/user/_recent_comments.html.eex:10
+#: lib/helheim_web/templates/admin/user/_recent_forum_replies.html.eex:10
+#: lib/helheim_web/templates/admin/user/_recent_forum_topics.html.eex:10
 #: lib/helheim_web/templates/mod/calendar_event/index.html.eex:11
 #, elixir-autogen
 msgid "When"
@@ -2271,14 +2271,14 @@ msgstr ""
 
 #: lib/helheim_web/templates/calendar_event/index.html.eex:5
 #: lib/helheim_web/templates/calendar_event/new.html.eex:1
-#: lib/helheim_web/templates/page/front_page.html.eex:70
+#: lib/helheim_web/templates/page/front_page.html.eex:58
 #, elixir-autogen
 msgid "Create event"
 msgstr ""
 
 #: lib/helheim_web/templates/calendar_event/index.html.eex:1
 #: lib/helheim_web/templates/calendar_event/show.html.eex:2
-#: lib/helheim_web/templates/layout/sidebar.html.eex:29
+#: lib/helheim_web/templates/layout/sidebar.html.eex:35
 #: lib/helheim_web/templates/layout/sidebar_mod.html.eex:6
 #: lib/helheim_web/templates/mod/calendar_event/index.html.eex:3
 #: lib/helheim_web/templates/mod/calendar_event/show.html.eex:3
@@ -2415,7 +2415,7 @@ msgid_plural "There are currently %{count} online users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:22
+#: lib/helheim_web/templates/layout/sidebar.html.eex:28
 #, elixir-autogen
 msgid "Online users"
 msgstr ""
@@ -2461,17 +2461,17 @@ msgstr ""
 msgid "%{count} people"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:64
+#: lib/helheim_web/templates/page/front_page.html.eex:52
 #, elixir-autogen
 msgid "It looks like there are no upcoming events..."
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:65
+#: lib/helheim_web/templates/page/front_page.html.eex:53
 #, elixir-autogen
 msgid "Tell us about an event so we can add it:"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:55
+#: lib/helheim_web/templates/page/front_page.html.eex:43
 #, elixir-autogen
 msgid "Events"
 msgstr ""
@@ -2513,7 +2513,7 @@ msgstr ""
 msgid "Moderators"
 msgstr ""
 
-#: lib/helheim_web/templates/layout/sidebar.html.eex:54
+#: lib/helheim_web/templates/layout/sidebar.html.eex:60
 #: lib/helheim_web/templates/page/staff.html.eex:3
 #, elixir-format, elixir-autogen
 msgid "Staff"
@@ -2716,6 +2716,7 @@ msgstr ""
 msgid "Latest listens"
 msgstr ""
 
+#: lib/helheim_web/templates/music/index.html.eex:28
 #: lib/helheim_web/templates/song/show.html.eex:36
 #, elixir-autogen, elixir-format
 msgid "Listens"
@@ -2726,6 +2727,7 @@ msgstr ""
 msgid "Music from %{username}"
 msgstr ""
 
+#: lib/helheim_web/templates/music/index.html.eex:94
 #: lib/helheim_web/templates/song/recent.html.eex:6
 #: lib/helheim_web/templates/song_listen/index.html.eex:9
 #: lib/helheim_web/templates/song_listen/index.html.eex:21
@@ -2744,7 +2746,8 @@ msgstr ""
 msgid "Recent listeners"
 msgstr ""
 
-#: lib/helheim_web/templates/page/front_page.html.eex:84
+#: lib/helheim_web/templates/music/index.html.eex:10
+#: lib/helheim_web/templates/page/front_page.html.eex:71
 #: lib/helheim_web/templates/song/recent.html.eex:1
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Recent listens"
@@ -2755,6 +2758,7 @@ msgstr ""
 msgid "Song"
 msgstr ""
 
+#: lib/helheim_web/templates/music/index.html.eex:92
 #: lib/helheim_web/templates/song_listen/index.html.eex:19
 #, elixir-autogen, elixir-format
 msgid "Top artists"
@@ -2785,7 +2789,7 @@ msgstr ""
 msgid "Remove my name from this song"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:162
+#: lib/helheim_web/controllers/song_controller.ex:177
 #, elixir-autogen, elixir-format
 msgid "Your listens have been removed from this song."
 msgstr ""
@@ -2795,6 +2799,7 @@ msgstr ""
 msgid "Album on Last.fm"
 msgstr ""
 
+#: lib/helheim_web/templates/music/artist.html.eex:24
 #: lib/helheim_web/templates/song/show.html.eex:53
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Artist on Last.fm"
@@ -2872,21 +2877,21 @@ msgstr ""
 msgid "Your Last.fm account is now connected!"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:56
-#: lib/helheim_web/templates/page/front_page.html.eex:98
-#: lib/helheim_web/templates/page/front_page.html.eex:106
+#: lib/helheim_web/controllers/song_controller.ex:59
+#: lib/helheim_web/templates/music/index.html.eex:135
+#: lib/helheim_web/templates/music/index.html.eex:143
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No songs have been listened to in this period yet..."
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:28
-#: lib/helheim_web/templates/page/front_page.html.eex:94
+#: lib/helheim_web/controllers/song_controller.ex:31
+#: lib/helheim_web/templates/music/index.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Top songs, past 24 hours"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:32
-#: lib/helheim_web/templates/page/front_page.html.eex:102
+#: lib/helheim_web/controllers/song_controller.ex:35
+#: lib/helheim_web/templates/music/index.html.eex:139
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Top songs, past 7 days"
 msgstr ""
@@ -2902,42 +2907,143 @@ msgid "Year"
 msgstr ""
 
 #: lib/helheim_web/templates/song/show.html.eex:11
-#: lib/helheim_web/views/song_view.ex:44
-#: lib/helheim_web/views/song_view.ex:45
+#: lib/helheim_web/views/song_view.ex:53
+#: lib/helheim_web/views/song_view.ex:54
 #, elixir-autogen, elixir-format
 msgid "Play preview"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:36
-#: lib/helheim_web/templates/page/front_page.html.eex:114
+#: lib/helheim_web/controllers/song_controller.ex:39
+#: lib/helheim_web/templates/music/index.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Most upvoted songs, past 24 hours"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:40
-#: lib/helheim_web/templates/page/front_page.html.eex:122
+#: lib/helheim_web/controllers/song_controller.ex:43
+#: lib/helheim_web/templates/music/index.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Most upvoted songs, past 7 days"
 msgstr ""
 
-#: lib/helheim_web/controllers/song_controller.ex:57
-#: lib/helheim_web/templates/page/front_page.html.eex:118
-#: lib/helheim_web/templates/page/front_page.html.eex:126
+#: lib/helheim_web/controllers/song_controller.ex:60
+#: lib/helheim_web/templates/music/index.html.eex:153
+#: lib/helheim_web/templates/music/index.html.eex:161
 #, elixir-autogen, elixir-format
 msgid "No songs have been upvoted in this period yet..."
 msgstr ""
 
-#: lib/helheim_web/views/song_view.ex:91
+#: lib/helheim_web/views/song_view.ex:111
 #, elixir-autogen, elixir-format
 msgid "Upvote"
 msgstr ""
 
+#: lib/helheim_web/templates/music/index.html.eex:32
 #: lib/helheim_web/templates/song/show.html.eex:40
 #, elixir-autogen, elixir-format
 msgid "Upvotes"
 msgstr ""
 
-#: lib/helheim_web/views/song_view.ex:92
+#: lib/helheim_web/views/song_view.ex:112
 #, elixir-autogen, elixir-format
 msgid "Remove your upvote"
+msgstr ""
+
+#: lib/helheim_web/views/music_view.ex:14
+#, elixir-autogen, elixir-format
+msgid "%{decade}s"
+msgstr ""
+
+#: lib/helheim_web/views/music_view.ex:21
+#, elixir-autogen, elixir-format
+msgid "%{short}s"
+msgstr ""
+
+#: lib/helheim_web/templates/music/artist.html.eex:3
+#: lib/helheim_web/templates/music/decade.html.eex:3
+#: lib/helheim_web/templates/music/genre.html.eex:3
+#, elixir-autogen, elixir-format
+msgid "All music"
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:24
+#, elixir-autogen, elixir-format
+msgid "Artists"
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:69
+#, elixir-autogen, elixir-format
+msgid "Decades"
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:4
+#, elixir-autogen, elixir-format
+msgid "Everything the site is listening to: the current charts, the genres and decades we keep coming back to, and the artists we play the most."
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:46
+#, elixir-autogen, elixir-format
+msgid "Genres"
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:16
+#, elixir-autogen, elixir-format
+msgid "Helheim in numbers"
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:36
+#, elixir-autogen, elixir-format
+msgid "Listeners"
+msgstr ""
+
+#: lib/helheim_web/templates/layout/sidebar.html.eex:10
+#: lib/helheim_web/templates/music/index.html.eex:1
+#, elixir-autogen, elixir-format
+msgid "Music"
+msgstr ""
+
+#: lib/helheim_web/templates/song/show.html.eex:90
+#, elixir-autogen, elixir-format
+msgid "No one has upvoted this song yet..."
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:48
+#, elixir-autogen, elixir-format
+msgid "No songs have been tagged with a genre yet..."
+msgstr ""
+
+#: lib/helheim_web/templates/music/artist.html.eex:35
+#: lib/helheim_web/templates/music/decade.html.eex:11
+#: lib/helheim_web/templates/music/genre.html.eex:11
+#, elixir-autogen, elixir-format
+msgid "No songs here yet..."
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:71
+#, elixir-autogen, elixir-format
+msgid "No songs with a known release year yet..."
+msgstr ""
+
+#: lib/helheim_web/templates/music/index.html.eex:20
+#, elixir-autogen, elixir-format
+msgid "Songs"
+msgstr ""
+
+#: lib/helheim_web/templates/music/artist.html.eex:30
+#, elixir-autogen, elixir-format
+msgid "The most listened to songs by %{artist}."
+msgstr ""
+
+#: lib/helheim_web/templates/music/decade.html.eex:6
+#, elixir-autogen, elixir-format
+msgid "The most listened to songs released in the %{decade}."
+msgstr ""
+
+#: lib/helheim_web/templates/music/genre.html.eex:6
+#, elixir-autogen, elixir-format
+msgid "The most listened to songs tagged %{genre}."
+msgstr ""
+
+#: lib/helheim_web/templates/song/show.html.eex:88
+#, elixir-autogen, elixir-format
+msgid "Upvoted by"
 msgstr ""

--- a/priv/repo/migrations/20260725000001_add_music_genre_index.exs
+++ b/priv/repo/migrations/20260725000001_add_music_genre_index.exs
@@ -1,0 +1,13 @@
+defmodule Helheim.Repo.Migrations.AddMusicGenreIndex do
+  use Ecto.Migration
+
+  def change do
+    # Serves both the top genre aggregate, which walks every position 1 tag, and
+    # the genre pages, which look up one tag's songs. The existing
+    # songs_tags(tag_id) index matches a song's other tags too and does not
+    # carry position, so it needs a heap fetch per row just to discard four rows
+    # in five; leading with tag_id and including song_id answers both queries
+    # from the index alone.
+    create index(:songs_tags, [:tag_id, :song_id], where: "position = 1", name: :songs_tags_genre_index)
+  end
+end

--- a/test/helheim/artist_test.exs
+++ b/test/helheim/artist_test.exs
@@ -1,0 +1,28 @@
+defmodule Helheim.ArtistTest do
+  use Helheim.DataCase
+  alias Helheim.Artist
+
+  describe "with_records/1" do
+    test "returns an empty list unchanged" do
+      assert Artist.with_records([]) == []
+    end
+
+    test "attaches the artist record, matching the name case-insensitively" do
+      artist = insert(:artist, name: "Metallica")
+
+      assert [{"metallica", 3, found}] = Artist.with_records([{"metallica", 3}])
+      assert found.id == artist.id
+    end
+
+    test "passes through names with no artist record" do
+      assert Artist.with_records([{"Nobody", 1}]) == [{"Nobody", 1, nil}]
+    end
+
+    test "keeps the order of the aggregated rows" do
+      insert(:artist, name: "Bathory")
+
+      assert [{"Metallica", 5, nil}, {"Bathory", 2, %Artist{}}] =
+               Artist.with_records([{"Metallica", 5}, {"Bathory", 2}])
+    end
+  end
+end

--- a/test/helheim/music/stats_test.exs
+++ b/test/helheim/music/stats_test.exs
@@ -1,0 +1,146 @@
+defmodule Helheim.Music.StatsTest do
+  use Helheim.DataCase
+  alias Helheim.Music.Stats
+
+  describe "top_genres/1" do
+    test "orders genres by the total listens of the songs they are the primary tag of" do
+      thrash = insert(:tag, name: "thrash metal")
+      doom = insert(:tag, name: "doom metal")
+      insert(:song_tag, song: insert(:song, listens_count: 3), tag: thrash)
+      insert(:song_tag, song: insert(:song, listens_count: 4), tag: thrash)
+      insert(:song_tag, song: insert(:song, listens_count: 5), tag: doom)
+
+      assert [{top, 7}, {runner_up, 5}] = Stats.top_genres(10)
+      assert top.id == thrash.id
+      assert runner_up.id == doom.id
+    end
+
+    test "does not count a tag that is not the song's primary tag" do
+      secondary = insert(:tag, name: "live")
+      insert(:song_tag, song: insert(:song, listens_count: 9), tag: secondary, position: 2)
+
+      assert Stats.top_genres(10) == []
+    end
+
+    test "does not include a genre whose songs have never been played" do
+      insert(:song_tag, song: insert(:song, listens_count: 0), tag: insert(:tag))
+
+      assert Stats.top_genres(10) == []
+    end
+
+    test "limits the number of results" do
+      for _ <- 1..3 do
+        insert(:song_tag, song: insert(:song, listens_count: 1), tag: insert(:tag))
+      end
+
+      assert length(Stats.top_genres(2)) == 2
+    end
+  end
+
+  describe "top_artists/1" do
+    test "sums the listens of every song by the same artist" do
+      insert(:song, artist_name: "Metallica", listens_count: 2)
+      insert(:song, artist_name: "Metallica", listens_count: 3)
+      insert(:song, artist_name: "Bathory", listens_count: 4)
+
+      assert [{"Metallica", 5, _}, {"Bathory", 4, _}] = Stats.top_artists(10)
+    end
+
+    test "treats artist names that differ only in casing as the same artist" do
+      insert(:song, artist_name: "Metallica", listens_count: 2)
+      insert(:song, artist_name: "metallica", listens_count: 3)
+
+      assert [{_name, 5, _artist}] = Stats.top_artists(10)
+    end
+
+    test "attaches the enriched artist record when there is one" do
+      insert(:song, artist_name: "Bathory", listens_count: 1)
+      artist = insert(:artist, name: "Bathory")
+
+      assert [{"Bathory", 1, %Helheim.Artist{} = found}] = Stats.top_artists(10)
+      assert found.id == artist.id
+    end
+
+    test "returns artists without an enriched record too" do
+      insert(:song, artist_name: "Bathory", listens_count: 1)
+
+      assert [{"Bathory", 1, nil}] = Stats.top_artists(10)
+    end
+
+    test "does not include songs that have never been played" do
+      insert(:song, artist_name: "Bathory", listens_count: 0)
+
+      assert Stats.top_artists(10) == []
+    end
+
+    test "limits the number of results" do
+      insert(:song, artist_name: "Metallica", listens_count: 1)
+      insert(:song, artist_name: "Bathory", listens_count: 1)
+      insert(:song, artist_name: "Mayhem", listens_count: 1)
+
+      assert length(Stats.top_artists(2)) == 2
+    end
+  end
+
+  describe "listens_per_decade/0" do
+    test "buckets release years into decades, ascending" do
+      insert(:song, release_year: 1986, listens_count: 2)
+      insert(:song, release_year: 1988, listens_count: 3)
+      insert(:song, release_year: 1994, listens_count: 1)
+
+      assert Stats.listens_per_decade() == [{1980, 5}, {1990, 1}]
+    end
+
+    test "leaves out songs with no release year" do
+      insert(:song, release_year: nil, listens_count: 4)
+
+      assert Stats.listens_per_decade() == []
+    end
+
+    test "leaves out implausible release years from bad metadata" do
+      insert(:song, release_year: 3025, listens_count: 4)
+
+      assert Stats.listens_per_decade() == []
+    end
+
+    test "leaves out songs that have never been played" do
+      insert(:song, release_year: 1986, listens_count: 0)
+
+      assert Stats.listens_per_decade() == []
+    end
+  end
+
+  describe "totals/0" do
+    test "returns zeroes when nothing has been tracked yet" do
+      assert Stats.totals() == %{songs: 0, artists: 0, listens: 0, upvotes: 0, listeners: 0}
+    end
+
+    test "counts songs, artists, listens and upvotes" do
+      song = insert(:song, artist_name: "Metallica", listens_count: 3, upvotes_count: 2)
+      insert(:song, artist_name: "Bathory", listens_count: 1, upvotes_count: 0)
+      insert(:song_listen, song: song)
+
+      totals = Stats.totals()
+      assert totals.songs == 2
+      assert totals.artists == 2
+      assert totals.listens == 4
+      assert totals.upvotes == 2
+    end
+
+    test "counts each listener only once" do
+      listener = insert(:user)
+      song = insert(:song)
+      insert(:song_listen, user: listener, song: song, played_at: Timex.shift(Timex.now, minutes: -10))
+      insert(:song_listen, user: listener, song: song, played_at: Timex.shift(Timex.now, minutes: -5))
+
+      assert Stats.totals().listeners == 1
+    end
+
+    test "counts artist names that differ only in casing as one artist" do
+      insert(:song, artist_name: "Metallica")
+      insert(:song, artist_name: "metallica")
+
+      assert Stats.totals().artists == 1
+    end
+  end
+end

--- a/test/helheim_web/controllers/music_controller_test.exs
+++ b/test/helheim_web/controllers/music_controller_test.exs
@@ -1,0 +1,257 @@
+defmodule HelheimWeb.MusicControllerTest do
+  use HelheimWeb.ConnCase
+
+  ##############################################################################
+  # index/2
+  describe "index/2 when signed in" do
+    setup [:create_and_sign_in_user]
+
+    test "it shows the site wide totals", %{conn: conn} do
+      insert(:song, artist_name: "Metallica", listens_count: 3, upvotes_count: 2)
+
+      conn = get conn, "/music"
+      response = html_response(conn, 200)
+      assert response =~ gettext("Helheim in numbers")
+      assert response =~ gettext("Listeners")
+    end
+
+    test "it shows the top genres with a link to each genre", %{conn: conn} do
+      tag = insert(:tag, name: "thrash metal")
+      insert(:song_tag, song: insert(:song, listens_count: 4), tag: tag)
+
+      conn = get conn, "/music"
+      response = html_response(conn, 200)
+      assert response =~ gettext("Genres")
+      assert response =~ "Thrash Metal"
+      assert response =~ "/music/genres/#{tag.id}"
+    end
+
+    test "it shows the decades with a link to each decade, in chronological order", %{conn: conn} do
+      insert(:song, release_year: 1994, listens_count: 1)
+      insert(:song, release_year: 1986, listens_count: 2)
+
+      conn = get conn, "/music"
+      response = html_response(conn, 200)
+      assert response =~ gettext("Decades")
+      assert response =~ "/music/decades/1980"
+      assert response =~ "/music/decades/1990"
+
+      [_before, after_eighties] = String.split(response, "/music/decades/1980", parts: 2)
+      assert after_eighties =~ "/music/decades/1990"
+    end
+
+    test "it does not show songs without a release year among the decades", %{conn: conn} do
+      insert(:song, release_year: nil, listens_count: 3)
+
+      conn = get conn, "/music"
+      assert html_response(conn, 200) =~ gettext("No songs with a known release year yet...")
+    end
+
+    test "it shows the top artists with their enriched details and a link to each artist", %{conn: conn} do
+      insert(:song, artist_name: "Bathory", listens_count: 5)
+      artist = insert(:artist, name: "Bathory", country_code: "SE", country_name: "Sweden")
+
+      conn = get conn, "/music"
+      response = html_response(conn, 200)
+      assert response =~ gettext("Top artists")
+      assert response =~ "Bathory"
+      assert response =~ artist.image_url_medium
+      assert response =~ "Sweden"
+      assert response =~ "/music/artists/Bathory"
+    end
+
+    test "it shows the song charts that used to live on the front page", %{conn: conn} do
+      insert(:song_listen, song: insert(:song, title: "Orion"))
+      insert(:song_upvote, song: insert(:song, title: "Blackened"))
+
+      conn = get conn, "/music"
+      response = html_response(conn, 200)
+      assert response =~ gettext("Top songs, past 24 hours")
+      assert response =~ gettext("Top songs, past 7 days")
+      assert response =~ gettext("Most upvoted songs, past 24 hours")
+      assert response =~ gettext("Most upvoted songs, past 7 days")
+      assert response =~ "Orion"
+      assert response =~ "Blackened"
+    end
+
+    test "it does not show chart entries from ignored users", %{conn: conn, user: user} do
+      ignoree = insert(:user)
+      insert(:ignore, ignorer: user, ignoree: ignoree, enabled: true)
+      insert(:song_listen, user: ignoree, song: insert(:song, title: "Orion"))
+
+      conn = get conn, "/music"
+      refute html_response(conn, 200) =~ "Orion"
+    end
+  end
+
+  describe "index/2 when not signed in" do
+    test "it redirects to the sign in page", %{conn: conn} do
+      conn = get conn, "/music"
+      assert redirected_to(conn) =~ session_path(conn, :new)
+    end
+  end
+
+  ##############################################################################
+  # genre/2
+  describe "genre/2 when signed in" do
+    setup [:create_and_sign_in_user]
+
+    test "it shows the songs whose primary tag is the genre, most listened first", %{conn: conn} do
+      tag = insert(:tag, name: "thrash metal")
+      insert(:song_tag, song: insert(:song, title: "Creeping Death", listens_count: 1), tag: tag)
+      insert(:song_tag, song: insert(:song, title: "Battery", listens_count: 9), tag: tag)
+
+      conn = get conn, "/music/genres/#{tag.id}"
+      response = html_response(conn, 200)
+      assert response =~ "Thrash Metal"
+      assert response =~ "Creeping Death"
+
+      [_before, after_battery] = String.split(response, "Battery", parts: 2)
+      assert after_battery =~ "Creeping Death"
+    end
+
+    test "it does not show songs where the genre is only a secondary tag", %{conn: conn} do
+      tag = insert(:tag, name: "live")
+      insert(:song_tag, song: insert(:song, title: "Whiplash"), tag: tag, position: 2)
+
+      conn = get conn, "/music/genres/#{tag.id}"
+      refute html_response(conn, 200) =~ "Whiplash"
+    end
+
+    test "it shows a placeholder when the genre has no songs", %{conn: conn} do
+      tag = insert(:tag)
+
+      conn = get conn, "/music/genres/#{tag.id}"
+      assert html_response(conn, 200) =~ gettext("No songs here yet...")
+    end
+
+    test "it caps the page number", %{conn: conn} do
+      tag = insert(:tag)
+
+      conn = get conn, "/music/genres/#{tag.id}?page=999"
+      assert html_response(conn, 200)
+    end
+
+    test "it returns a 404 when the genre does not exist", %{conn: conn} do
+      assert_error_sent :not_found, fn ->
+        get conn, "/music/genres/1234567"
+      end
+    end
+  end
+
+  describe "genre/2 when not signed in" do
+    test "it redirects to the sign in page", %{conn: conn} do
+      conn = get conn, "/music/genres/#{insert(:tag).id}"
+      assert redirected_to(conn) =~ session_path(conn, :new)
+    end
+  end
+
+  ##############################################################################
+  # decade/2
+  describe "decade/2 when signed in" do
+    setup [:create_and_sign_in_user]
+
+    test "it shows the songs released in the decade and no others", %{conn: conn} do
+      insert(:song, title: "Master of Puppets", release_year: 1986)
+      insert(:song, title: "Physical Graffiti", release_year: 1975)
+
+      conn = get conn, "/music/decades/1980"
+      response = html_response(conn, 200)
+      assert response =~ "Master of Puppets"
+      refute response =~ "Physical Graffiti"
+    end
+
+    test "it redirects a year inside the decade to the canonical decade url", %{conn: conn} do
+      conn = get conn, "/music/decades/1986"
+      assert redirected_to(conn) == "/music/decades/1980"
+    end
+
+    test "it caps the page number", %{conn: conn} do
+      conn = get conn, "/music/decades/1980?page=999"
+      assert html_response(conn, 200)
+    end
+
+    test "it returns a 404 when the decade is not a year", %{conn: conn} do
+      conn = get conn, "/music/decades/eighties"
+      assert html_response(conn, 404) =~ gettext("The page you requested does not exist.")
+    end
+  end
+
+  describe "decade/2 when not signed in" do
+    test "it redirects to the sign in page", %{conn: conn} do
+      conn = get conn, "/music/decades/1980"
+      assert redirected_to(conn) =~ session_path(conn, :new)
+    end
+  end
+
+  ##############################################################################
+  # artist/2
+  describe "artist/2 when signed in" do
+    setup [:create_and_sign_in_user]
+
+    test "it shows the artist's songs, matching the name case-insensitively", %{conn: conn} do
+      insert(:song, title: "Creeping Death", artist_name: "Metallica")
+
+      conn = get conn, "/music/artists/metallica"
+      response = html_response(conn, 200)
+      assert response =~ "Metallica"
+      assert response =~ "Creeping Death"
+    end
+
+    test "it shows the enriched artist details when there is an artist record", %{conn: conn} do
+      insert(:song, artist_name: "Bathory", listens_count: 7)
+      artist = insert(:artist, name: "Bathory", country_code: "SE", country_name: "Sweden")
+
+      conn = get conn, "/music/artists/Bathory"
+      response = html_response(conn, 200)
+      assert response =~ artist.image_url_medium
+      assert response =~ "Sweden"
+      assert response =~ "7"
+    end
+
+    test "it renders without enriched details when there is no artist record", %{conn: conn} do
+      insert(:song, title: "Creeping Death", artist_name: "Metallica")
+
+      conn = get conn, "/music/artists/Metallica"
+      response = html_response(conn, 200)
+      assert response =~ "music-artist-image-placeholder"
+      assert response =~ "Creeping Death"
+    end
+
+    test "it handles an artist name containing a slash", %{conn: conn} do
+      insert(:song, title: "Back in Black", artist_name: "AC/DC")
+
+      conn = get conn, "/music/artists/AC/DC"
+      response = html_response(conn, 200)
+      assert response =~ "AC/DC"
+      assert response =~ "Back in Black"
+    end
+
+    test "it renders for an artist record whose songs are all gone", %{conn: conn} do
+      insert(:artist, name: "Bathory")
+
+      conn = get conn, "/music/artists/Bathory"
+      assert html_response(conn, 200) =~ gettext("No songs here yet...")
+    end
+
+    test "it caps the page number", %{conn: conn} do
+      insert(:song, artist_name: "Metallica")
+
+      conn = get conn, "/music/artists/Metallica?page=999"
+      assert html_response(conn, 200)
+    end
+
+    test "it returns a 404 for an artist the site has never heard of", %{conn: conn} do
+      conn = get conn, "/music/artists/Nobody%20At%20All"
+      assert html_response(conn, 404) =~ gettext("The page you requested does not exist.")
+    end
+  end
+
+  describe "artist/2 when not signed in" do
+    test "it redirects to the sign in page", %{conn: conn} do
+      insert(:song, artist_name: "Metallica")
+      conn = get conn, "/music/artists/Metallica"
+      assert redirected_to(conn) =~ session_path(conn, :new)
+    end
+  end
+end

--- a/test/helheim_web/controllers/page_controller_test.exs
+++ b/test/helheim_web/controllers/page_controller_test.exs
@@ -44,24 +44,23 @@ defmodule HelheimWeb.PageControllerTest do
       refute html_response(conn, 200) =~ gettext("Recent listens")
     end
 
-    test "it shows the top songs of the past 24 hours and past 7 days", %{conn: conn} do
-      song = insert(:song, title: "Orion")
-      insert_list(2, :song_listen, song: song)
+    test "it does not show the song charts, which live on the music page", %{conn: conn} do
+      insert(:song_listen, song: insert(:song, title: "Orion"))
+      insert(:song_upvote, song: insert(:song, title: "Blackened"))
 
       conn = get conn, "/front_page"
       response = html_response(conn, 200)
-      assert response =~ gettext("Top songs, past 24 hours")
-      assert response =~ gettext("Top songs, past 7 days")
+      refute response =~ gettext("Top songs, past 24 hours")
+      refute response =~ gettext("Top songs, past 7 days")
+      refute response =~ gettext("Most upvoted songs, past 24 hours")
+      refute response =~ gettext("Most upvoted songs, past 7 days")
     end
 
-    test "it shows the most upvoted songs of the past 24 hours and past 7 days even without recent listens", %{conn: conn} do
-      insert(:song_upvote, song: insert(:song, title: "Orion"))
+    test "it links to the music page", %{conn: conn} do
+      insert(:song_listen, song: insert(:song, title: "Orion"))
 
       conn = get conn, "/front_page"
-      response = html_response(conn, 200)
-      assert response =~ gettext("Most upvoted songs, past 24 hours")
-      assert response =~ gettext("Most upvoted songs, past 7 days")
-      assert response =~ "Orion"
+      assert html_response(conn, 200) =~ "/music"
     end
 
     test "it does not show the same song twice in the recent listens", %{conn: conn} do
@@ -71,10 +70,32 @@ defmodule HelheimWeb.PageControllerTest do
       insert(:song_listen, user: user, song: song, played_at: Timex.shift(Timex.now, minutes: -5))
 
       conn = get conn, "/front_page"
+      assert length(String.split(html_response(conn, 200), "Orion")) == 2
+    end
+
+    test "it shows at most 15 recent listens", %{conn: conn} do
+      insert_list(20, :song_listen)
+
+      conn = get conn, "/front_page"
+      assert length(String.split(html_response(conn, 200), "song-cover-frame")) == 16
+    end
+
+    test "it only shows the extra listen columns on wider screens", %{conn: conn} do
+      insert_list(11, :song_listen)
+
+      conn = get conn, "/front_page"
       response = html_response(conn, 200)
-      [_before, after_recent] = String.split(response, gettext("Recent listens"), parts: 2)
-      [recent_section, _rest] = String.split(after_recent, gettext("Top songs, past 24 hours"), parts: 2)
-      assert length(String.split(recent_section, "Orion")) == 2
+      assert response =~ "col-lg-4 hidden-sm-down"
+      assert response =~ "col-lg-4 hidden-md-down"
+    end
+
+    test "it does not render empty listen columns when there are only a few listens", %{conn: conn} do
+      insert_list(3, :song_listen)
+
+      conn = get conn, "/front_page"
+      response = html_response(conn, 200)
+      refute response =~ "col-lg-4 hidden-sm-down"
+      refute response =~ "col-lg-4 hidden-md-down"
     end
   end
 

--- a/test/helheim_web/controllers/song_controller_test.exs
+++ b/test/helheim_web/controllers/song_controller_test.exs
@@ -41,6 +41,13 @@ defmodule HelheimWeb.SongControllerTest do
       assert response =~ "https://lastfm.example/300x300/cover.jpg"
     end
 
+    test "it gives each cover link an accessible name", %{conn: conn} do
+      insert(:song_listen, song: insert(:song, title: "Creeping Death"))
+
+      conn = get conn, "/songs/recent"
+      assert html_response(conn, 200) =~ ~s(aria-label="Creeping Death")
+    end
+
     test "it does not show listens from ignored users", %{conn: conn, user: user} do
       ignoree = insert(:user)
       insert(:ignore, ignorer: user, ignoree: ignoree, enabled: true)
@@ -54,6 +61,13 @@ defmodule HelheimWeb.SongControllerTest do
       insert(:song_listen)
       conn = get conn, "/songs/recent", %{"page" => "999"}
       assert html_response(conn, 200)
+    end
+
+    test "it falls back to the first page when the page number is not a number", %{conn: conn} do
+      insert(:song_listen, song: insert(:song, title: "Creeping Death"))
+
+      conn = get conn, "/songs/recent", %{"page" => "abc"}
+      assert html_response(conn, 200) =~ "Creeping Death"
     end
 
     test "it renders a placeholder when a song has no cover art", %{conn: conn} do

--- a/test/helheim_web/controllers/song_controller_test.exs
+++ b/test/helheim_web/controllers/song_controller_test.exs
@@ -26,7 +26,19 @@ defmodule HelheimWeb.SongControllerTest do
 
       conn = get conn, "/songs/recent"
       response = html_response(conn, 200)
-      assert length(String.split(response, "Creeping Death")) == 2
+      # One title attribute per grid tile, so one occurrence means one tile.
+      assert length(String.split(response, "title=\"Creeping Death\"")) == 2
+    end
+
+    test "it renders the listens as a grid of cover art", %{conn: conn} do
+      song = insert(:song, cover_image_url: "https://lastfm.example/300x300/cover.jpg")
+      insert(:song_listen, song: song)
+
+      conn = get conn, "/songs/recent"
+      response = html_response(conn, 200)
+      assert response =~ "song-grid"
+      assert response =~ "song-grid-cover"
+      assert response =~ "https://lastfm.example/300x300/cover.jpg"
     end
 
     test "it does not show listens from ignored users", %{conn: conn, user: user} do
@@ -45,11 +57,11 @@ defmodule HelheimWeb.SongControllerTest do
     end
 
     test "it renders a placeholder when a song has no cover art", %{conn: conn} do
-      song = insert(:song, cover_image_url_small: nil)
+      song = insert(:song, cover_image_url: nil, cover_image_url_large: nil, cover_image_url_small: nil)
       insert(:song_listen, song: song)
 
       conn = get conn, "/songs/recent"
-      assert html_response(conn, 200) =~ "song-cover-placeholder"
+      assert html_response(conn, 200) =~ "song-grid-cover-placeholder"
     end
   end
 
@@ -127,12 +139,76 @@ defmodule HelheimWeb.SongControllerTest do
       assert response =~ "https://www.last.fm/music/Metallica/Ride%20the%20Lightning"
     end
 
-    test "it shows the most recent listeners of the song", %{conn: conn} do
+    test "it shows the most recent listeners of the song as a grid of avatars", %{conn: conn} do
       song = insert(:song)
       listen = insert(:song_listen, song: song)
 
       conn = get conn, "/songs/#{song.id}"
-      assert html_response(conn, 200) =~ listen.user.username
+      response = html_response(conn, 200)
+      assert response =~ gettext("Recent listeners")
+      assert response =~ "avatar-list"
+      assert response =~ listen.user.username
+    end
+
+    test "it shows a listener only once when they played the song on repeat", %{conn: conn} do
+      song = insert(:song)
+      listener = insert(:user)
+      insert(:song_listen, user: listener, song: song, played_at: Timex.shift(Timex.now, minutes: -10))
+      insert(:song_listen, user: listener, song: song, played_at: Timex.shift(Timex.now, minutes: -5))
+
+      conn = get conn, "/songs/#{song.id}"
+      assert length(String.split(html_response(conn, 200), "\"/profiles/#{listener.id}\"")) == 2
+    end
+
+    test "it shows a placeholder when no one has listened to the song", %{conn: conn} do
+      song = insert(:song)
+
+      conn = get conn, "/songs/#{song.id}"
+      assert html_response(conn, 200) =~ gettext("No one has listened to this song yet...")
+    end
+
+    test "it shows the users who upvoted the song as a grid of avatars", %{conn: conn} do
+      song = insert(:song)
+      upvote = insert(:song_upvote, song: song)
+
+      conn = get conn, "/songs/#{song.id}"
+      response = html_response(conn, 200)
+      assert response =~ gettext("Upvoted by")
+      assert response =~ upvote.user.username
+    end
+
+    test "it shows a placeholder when no one has upvoted the song", %{conn: conn} do
+      song = insert(:song)
+
+      conn = get conn, "/songs/#{song.id}"
+      assert html_response(conn, 200) =~ gettext("No one has upvoted this song yet...")
+    end
+
+    test "it does not show upvoters who block the current user", %{conn: conn, user: user} do
+      song = insert(:song)
+      blocker = insert(:user, username: "blocky-mc-blockface")
+      insert(:block, blocker: blocker, blockee: user)
+      insert(:song_upvote, song: song, user: blocker)
+
+      conn = get conn, "/songs/#{song.id}"
+      refute html_response(conn, 200) =~ "blocky-mc-blockface"
+    end
+
+    test "it does not show upvoters that the current user ignores", %{conn: conn, user: user} do
+      song = insert(:song)
+      ignoree = insert(:user, username: "ignored-individual")
+      insert(:ignore, ignorer: user, ignoree: ignoree, enabled: true)
+      insert(:song_upvote, song: song, user: ignoree)
+
+      conn = get conn, "/songs/#{song.id}"
+      refute html_response(conn, 200) =~ "ignored-individual"
+    end
+
+    test "it links the artist to their music page", %{conn: conn} do
+      song = insert(:song, artist_name: "Metallica")
+
+      conn = get conn, "/songs/#{song.id}"
+      assert html_response(conn, 200) =~ "/music/artists/Metallica"
     end
 
     test "it does not show listeners who block the current user", %{conn: conn, user: user} do
@@ -160,13 +236,12 @@ defmodule HelheimWeb.SongControllerTest do
         release_year: 1986,
         cover_image_url: "https://lastfm.freetls.fastly.net/i/u/300x300/abc.jpg",
         cover_image_url_large: "https://lastfm.freetls.fastly.net/i/u/500x500/abc.jpg")
-      tag = insert(:tag, name: "thrash metal")
-      Repo.insert!(%Helheim.SongTag{song_id: song.id, tag_id: tag.id, position: 1})
+      insert(:song_tag, song: song, tag: insert(:tag, name: "thrash metal"))
 
       conn = get conn, "/songs/#{song.id}"
       response = html_response(conn, 200)
       assert response =~ "1986"
-      assert response =~ "thrash metal"
+      assert response =~ "Thrash Metal"
       assert response =~ "500x500"
     end
 

--- a/test/helheim_web/pagination_sanitization_test.exs
+++ b/test/helheim_web/pagination_sanitization_test.exs
@@ -26,5 +26,22 @@ defmodule HelheimWeb.PaginationSanitizationTest do
     test "it returns 1 when passing zero as a string" do
       assert PaginationSanitization.sanitized_page("0") == 1
     end
+
+    test "it returns 1 when passing something that is not a number" do
+      assert PaginationSanitization.sanitized_page("abc") == 1
+      assert PaginationSanitization.sanitized_page("2abc") == 1
+      assert PaginationSanitization.sanitized_page("1.5") == 1
+      assert PaginationSanitization.sanitized_page(" ") == 1
+    end
+  end
+
+  describe "sanitized_page/2" do
+    test "it caps the page at the given maximum" do
+      assert PaginationSanitization.sanitized_page("500", 100) == 100
+    end
+
+    test "it returns 1 when passing something that is not a number" do
+      assert PaginationSanitization.sanitized_page("abc", 100) == 1
+    end
   end
 end

--- a/test/helheim_web/views/music_helpers_test.exs
+++ b/test/helheim_web/views/music_helpers_test.exs
@@ -1,0 +1,43 @@
+defmodule HelheimWeb.MusicHelpersTest do
+  use ExUnit.Case, async: true
+  import HelheimWeb.MusicHelpers
+
+  describe "tag_label/1" do
+    test "it upper cases the first letter of each word" do
+      assert tag_label("thrash metal") == "Thrash Metal"
+      assert tag_label("electronic body music") == "Electronic Body Music"
+    end
+
+    test "it treats a hyphen as a word boundary" do
+      assert tag_label("post-punk") == "Post-Punk"
+      assert tag_label("avant-garde metal") == "Avant-Garde Metal"
+    end
+
+    test "it treats an ampersand and a slash as word boundaries" do
+      assert tag_label("r&b") == "R&B"
+      assert tag_label("rock/pop") == "Rock/Pop"
+    end
+
+    test "it does not treat a digit as a word boundary" do
+      assert tag_label("80s") == "80s"
+      assert tag_label("00s pop") == "00s Pop"
+    end
+
+    test "it leaves an acronym someone typed properly alone" do
+      assert tag_label("NWOBHM") == "NWOBHM"
+      assert tag_label("EBM industrial") == "EBM Industrial"
+    end
+
+    test "it handles non-ascii letters" do
+      assert tag_label("åndelig musik") == "Åndelig Musik"
+    end
+
+    test "it leaves an already labelled tag unchanged" do
+      assert tag_label("Black Metal") == "Black Metal"
+    end
+
+    test "it passes nil through" do
+      assert tag_label(nil) == nil
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -252,6 +252,14 @@ defmodule Helheim.Factory do
     }
   end
 
+  def song_tag_factory do
+    %Helheim.SongTag{
+      song: build(:song),
+      tag: build(:tag),
+      position: 1
+    }
+  end
+
   def song_listen_factory do
     %Helheim.SongListen{
       user: build(:user),


### PR DESCRIPTION
## Why

The music feature had grown to five cards on the front page — recent listens plus four chart cards — which was more room than music deserved next to blogs, forums, events and photos. Music now gets its own destination, and the front page keeps only the latest listens.

## Front page

Five music cards become one. "Recent listens" uses the horizontal space it has: 15 listens laid out in up to three columns of five, with the second and third hidden below `md` and `lg`, so **a phone shows 5, a tablet 10 and a desktop 15**. Fewer than 15 listens yields fewer columns rather than empty ones. "Show All" now points at the new music page, which is the front page's only gateway into music.

## The new `/music` page

Sidebar link above Forums. Carries the four charts that left the front page, plus a stat strip (songs, artists, listens, likes, listeners), a genre bar chart, a decade equalizer and a top-artist podium with a ranked list. All three visualizations are clickable:

- `/music/genres/:id`
- `/music/decades/1980` (a year inside the decade redirects to the canonical url)
- `/music/artists/*name`

The artist route is a **glob** rather than an `:id` because songs, not the `artists` table, are the source of truth for artist identity (`songs.artist_id` stays nil until enrichment runs), and a glob lets a name containing a slash — `AC/DC` — travel as real path segments instead of a percent-encoded slash a proxy might rewrite. There's a test for it.

A url naming no decade or no artist renders the site's own 404 page. Worth knowing why it isn't `Repo.get!`-style: raising `Phoenix.Router.NoRouteError` from inside an action interacts badly with the router's `Plug.ErrorHandler` and produced a response with no status at all, so `assert_error_sent` couldn't see it.

## Two decisions in the data layer worth a look

The aggregates live in a new `Helheim.Music.Stats`, sibling to `Charts` rather than more functions on it — these are all-time and slow-moving, want a longer ttl, and must not be dropped on every vote.

1. **They sum `songs.listens_count` instead of counting `song_listens` rows.** With no time window, counting rows means reading the whole listens table on every recompute. That counter is maintained exactly and is already the sort key of the pages these charts link to, so the two cannot disagree.
2. **They are not filtered by the viewer's ignore list**, unlike the windowed charts. A genre bar, a decade bar and an artist name attribute no content to any user, so there is nothing of an ignored user's to hide — which keeps one query body per aggregate and makes every result cacheable for every viewer. The four `Charts.*` calls on the page do keep their ignore filtering, since they render songs.

Nothing here is added to `Charts.invalidate_cache/0`: none of these values embeds a `Song` whose `upvotes_count` a badge renders. That rule is now written into the `Charts` docs so the next person has a decision procedure rather than a list to guess at.

`config/test.exs` gets `music_stats_cache_ttl_ms: 0` — mandatory, not cosmetic: `Helheim.Cache` is ETS and isn't covered by the SQL sandbox, so a cached page would leak between tests.

## Song lists as cover grids

Full page song lists — the charts, recent listens, the new browse pages, and a profile's listen history — render as a grid of large cover art instead of 64px thumbnails, using the 300×300 `cover_image_url` rather than the thumbnail scaled up. The grid is `auto-fill` so the column count follows the available width with no breakpoint ladder: 2 covers on a phone, 5–6 on a desktop. The compact summary cards on the front page and the music page keep the thumbnail rows, which suit a narrow card.

## Song page

"Recent listeners" becomes a grid of profile photos like the front page's recently-logged-in grid, and gains a matching grid of the users who **liked** the song. Repeat plays collapse to one avatar per listener (previously a song played 30 times would have rendered 30 identical faces), and the limit went 10 → 50 now that each entry is an avatar rather than a text row. The artist name in the metadata table links to their new page.

## Genre labels

Title cased wherever they render. Only the leading letter of each word is touched, so an acronym someone typed properly survives — `NWOBHM` stays put where capitalizing whole words would flatten it to `Nwobhm`. Word boundaries are any non-alphanumeric, so `post-punk` → `Post-Punk` and `r&b` → `R&B`, while a digit is not a boundary so `80s` stays `80s`.

## Refactors picked up along the way

- `SongListenController`'s private `with_artist_records/1` → `Artist.with_records/1` (two controllers need it; the existing test covers the move unchanged)
- `SongController`'s private `capped_paginate/2` → `PaginationSanitization`
- The avatar grid → a shared partial with three call sites
- The paginated song list body → a partial shared by the chart and browse pages

## Notes for the reviewer

- **One migration**: a partial `songs_tags` index on `position = 1`, serving both the top-genre aggregate and the genre pages. Indexes on `songs(release_year)` and `songs(listens_count)` were considered and deliberately skipped as speculative — reasoning is in the migration and the plan.
- **Requires an asset rebuild** for the new `assets/css/_music.scss` and the song grid styles. `priv/static` is gitignored, so nothing is committed.
- 19 new Danish strings translated; no existing `msgstr` removed or left fuzzy.
- `mix test`: **1673 tests, 0 failures.**
- Verified in a browser at 375 / 820 / 1200 / 1400px: the 5/10/15 listen columns, both avatar grids, the cover grids, the genre and decade charts (including that the equalizer bars still scale correctly now that the track height comes from flex), and every drill-down page. No horizontal overflow at 375px, console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Music dashboard with stats (totals, top genres/artists) plus genre/decade browsing and artist pages.
  * Added new recent listens and chart-style song rankings with upvote controls and responsive song/cover grids.
  * Added Music navigation and an artist tile layout, plus shared UI for avatar grids and song lists.
* **Bug Fixes**
  * Improved pagination behavior, canonical decade handling, and 404/error rendering; clarified empty states.
  * Prevented hidden-user data from appearing in listener/upvote displays.
* **Style**
  * Refreshed music page and grid styling, including better cover/placeholder, badges, and tooltips.
* **Tests**
  * Added coverage for music stats, controllers, helpers, and pagination sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->